### PR TITLE
use built-in cache of actions/setup-go

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,23 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Setup Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: 1.20.x
-
     - name: Checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
-    - name: Load cached dependencies
-      uses: actions/cache@v3
+    - name: Setup Go
+      uses: actions/setup-go@v4
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version: 1.20.x
 
     - name: Prepare release
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,13 +20,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
+    - name: Checkout code
+      uses: actions/checkout@v3
+
     - name: Install Go
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-
-    - name: Checkout code
-      uses: actions/checkout@v3
+        cache-dependency-path: '**/go.sum'
 
     - name: Vet and build
       run: |


### PR DESCRIPTION
From [actions/setup-go@v4.0.0](https://github.com/actions/setup-go/releases/tag/v4.0.0), the action caches the dependencies by default. We don't need to use actions/cache any more.

In addition, caching the dependencies requires `go.sum`. actions/checkout should precede actions/setup-go.