### PR TITLE
Update resources links in README and CONTRIBUTIONS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ First off, thank you for taking an interest to contribute to this project!
 
 ## Opening issues
 
-When opening a [new issue](https://github.com/uber/mock/issues/new/choose)
+When opening a [new issue](https://github.com/uber-go/mock/issues/new/choose)
 please:
 
-1. Make sure there are not other open/closed issues asking/reporting/requesting
+1. Make sure there are no other open/closed issues asking/reporting/requesting
    the same thing.
 1. Choose one of our provided templates and fill out as much information as
    possible.
@@ -16,4 +16,4 @@ please:
 
 We gladly accept contributions from the community. Before opening a pull request
 please make sure to create an issue for discussion first. This helps us decide
-what action should be taken in regards to the issue.
+what action should be taken in regard to the issue.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ gomock is a mocking framework for the [Go programming language][golang]. It
 integrates well with Go's built-in `testing` package, but can be used in other
 contexts too.
 
-This project originates from Google's `golang/mock` repo. Unfortunately Google
+This project originates from Google's `golang/mock` repo. Unfortunately, Google
 no longer maintains this project, and given the heavy usage of gomock project
 within Uber, we've decided to fork and maintain this going forward at Uber.
 
-Contributions are welcome in the form of GitHub issue or PR!
+[Contributions](./CONTRIBUTING.md) are welcome in the form of GitHub issue or PR!
 
 ## Supported Go Versions
 
@@ -247,9 +247,9 @@ gomock.GotFormatterAdapter(
 
 If the received value is `3`, then it will be printed as `03`.
 
-[golang]:              http://golang.org/
-[golang-install]:      http://golang.org/doc/install.html#releases
-[ci-badge]:            https://github.com/uber/mock/actions/workflows/test.yaml/badge.svg
-[ci-runs]:             https://github.com/uber/mock/actions
+[golang]:              http://go.dev/
+[golang-install]:      http://go.dev/doc/install.html#releases
+[ci-badge]:            https://github.com/uber-go/mock/actions/workflows/test.yaml/badge.svg
+[ci-runs]:             https://github.com/uber-go/mock/actions
 [reference-badge]:     https://pkg.go.dev/badge/go.uber.org/mock.svg
 [reference]:           https://pkg.go.dev/go.uber.org/mock


### PR DESCRIPTION
This PR changes URLs in the docs:
- replace `https://github.com/uber/mock` to `https://github.com/uber-go/mock`;
- replace `https://golang.org/` to `https://go.dev/`;
- update README with a link to CONTRIBUTIONS.md;
- fix grammar issues.