### PR TITLE
Replace 'interface{}' with 'any'

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ modifies how the `Got` value is formatted:
 
 ```go
 gomock.GotFormatterAdapter(
-  gomock.GotFormatterFunc(func(i interface{}) string {
+  gomock.GotFormatterFunc(func(i any) string {
     // Leading 0s
     return fmt.Sprintf("%02d", i)
   }),

--- a/gomock/call.go
+++ b/gomock/call.go
@@ -25,7 +25,7 @@ import (
 type Call struct {
 	t TestHelper // for triggering test failures on invalid call setup
 
-	receiver   interface{}  // the receiver of the method call
+	receiver   any          // the receiver of the method call
 	method     string       // the name of the method
 	methodType reflect.Type // the type of the method
 	args       []Matcher    // the args
@@ -41,12 +41,12 @@ type Call struct {
 	// actions are called when this Call is called. Each action gets the args and
 	// can set the return values by returning a non-nil slice. Actions run in the
 	// order they are created.
-	actions []func([]interface{}) []interface{}
+	actions []func([]any) []any
 }
 
 // newCall creates a *Call. It requires the method type in order to support
 // unexported methods.
-func newCall(t TestHelper, receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
+func newCall(t TestHelper, receiver any, method string, methodType reflect.Type, args ...any) *Call {
 	t.Helper()
 
 	// TODO: check arity, types.
@@ -67,9 +67,9 @@ func newCall(t TestHelper, receiver interface{}, method string, methodType refle
 	// and this line changes, i.e. this code is wrapped in another anonymous function.
 	// 0 is us, 1 is RecordCallWithMethodType(), 2 is the generated recorder, and 3 is the user's test.
 	origin := callerInfo(3)
-	actions := []func([]interface{}) []interface{}{func([]interface{}) []interface{} {
+	actions := []func([]any) []any{func([]any) []any {
 		// Synthesize the zero value for each of the return args' types.
-		rets := make([]interface{}, methodType.NumOut())
+		rets := make([]any, methodType.NumOut())
 		for i := 0; i < methodType.NumOut(); i++ {
 			rets[i] = reflect.Zero(methodType.Out(i)).Interface()
 		}
@@ -107,13 +107,13 @@ func (c *Call) MaxTimes(n int) *Call {
 
 // DoAndReturn declares the action to run when the call is matched.
 // The return values from this function are returned by the mocked function.
-// It takes an interface{} argument to support n-arity functions.
+// It takes an any argument to support n-arity functions.
 // The anonymous function must match the function signature mocked method.
-func (c *Call) DoAndReturn(f interface{}) *Call {
+func (c *Call) DoAndReturn(f any) *Call {
 	// TODO: Check arity and types here, rather than dying badly elsewhere.
 	v := reflect.ValueOf(f)
 
-	c.addAction(func(args []interface{}) []interface{} {
+	c.addAction(func(args []any) []any {
 		c.t.Helper()
 		ft := v.Type()
 		if c.methodType.NumIn() != ft.NumIn() {
@@ -136,7 +136,7 @@ func (c *Call) DoAndReturn(f interface{}) *Call {
 			}
 		}
 		vRets := v.Call(vArgs)
-		rets := make([]interface{}, len(vRets))
+		rets := make([]any, len(vRets))
 		for i, ret := range vRets {
 			rets[i] = ret.Interface()
 		}
@@ -148,13 +148,13 @@ func (c *Call) DoAndReturn(f interface{}) *Call {
 // Do declares the action to run when the call is matched. The function's
 // return values are ignored to retain backward compatibility. To use the
 // return values call DoAndReturn.
-// It takes an interface{} argument to support n-arity functions.
+// It takes an any argument to support n-arity functions.
 // The anonymous function must match the function signature mocked method.
-func (c *Call) Do(f interface{}) *Call {
+func (c *Call) Do(f any) *Call {
 	// TODO: Check arity and types here, rather than dying badly elsewhere.
 	v := reflect.ValueOf(f)
 
-	c.addAction(func(args []interface{}) []interface{} {
+	c.addAction(func(args []any) []any {
 		c.t.Helper()
 		ft := v.Type()
 		if c.methodType.NumIn() != ft.NumIn() {
@@ -183,7 +183,7 @@ func (c *Call) Do(f interface{}) *Call {
 }
 
 // Return declares the values to be returned by the mocked function call.
-func (c *Call) Return(rets ...interface{}) *Call {
+func (c *Call) Return(rets ...any) *Call {
 	c.t.Helper()
 
 	mt := c.methodType
@@ -215,7 +215,7 @@ func (c *Call) Return(rets ...interface{}) *Call {
 		}
 	}
 
-	c.addAction(func([]interface{}) []interface{} {
+	c.addAction(func([]any) []any {
 		return rets
 	})
 
@@ -231,7 +231,7 @@ func (c *Call) Times(n int) *Call {
 // SetArg declares an action that will set the nth argument's value,
 // indirected through a pointer. Or, in the case of a slice and map, SetArg
 // will copy value's elements/key-value pairs into the nth argument.
-func (c *Call) SetArg(n int, value interface{}) *Call {
+func (c *Call) SetArg(n int, value any) *Call {
 	c.t.Helper()
 
 	mt := c.methodType
@@ -262,7 +262,7 @@ func (c *Call) SetArg(n int, value interface{}) *Call {
 			n, at, c.origin)
 	}
 
-	c.addAction(func(args []interface{}) []interface{} {
+	c.addAction(func(args []any) []any {
 		v := reflect.ValueOf(value)
 		switch reflect.TypeOf(args[n]).Kind() {
 		case reflect.Slice:
@@ -323,7 +323,7 @@ func (c *Call) String() string {
 
 // Tests if the given call matches the expected call.
 // If yes, returns nil. If no, returns error with message explaining why it does not match.
-func (c *Call) matches(args []interface{}) error {
+func (c *Call) matches(args []any) error {
 	if !c.methodType.IsVariadic() {
 		if len(args) != len(c.args) {
 			return fmt.Errorf("expected call at %s has the wrong number of arguments. Got: %d, want: %d",
@@ -429,7 +429,7 @@ func (c *Call) dropPrereqs() (preReqs []*Call) {
 	return
 }
 
-func (c *Call) call() []func([]interface{}) []interface{} {
+func (c *Call) call() []func([]any) []any {
 	c.numCalls++
 	return c.actions
 }
@@ -441,14 +441,14 @@ func InOrder(calls ...*Call) {
 	}
 }
 
-func setSlice(arg interface{}, v reflect.Value) {
+func setSlice(arg any, v reflect.Value) {
 	va := reflect.ValueOf(arg)
 	for i := 0; i < v.Len(); i++ {
 		va.Index(i).Set(v.Index(i))
 	}
 }
 
-func setMap(arg interface{}, v reflect.Value) {
+func setMap(arg any, v reflect.Value) {
 	va := reflect.ValueOf(arg)
 	for _, e := range va.MapKeys() {
 		va.SetMapIndex(e, reflect.Value{})
@@ -458,11 +458,11 @@ func setMap(arg interface{}, v reflect.Value) {
 	}
 }
 
-func (c *Call) addAction(action func([]interface{}) []interface{}) {
+func (c *Call) addAction(action func([]any) []any) {
 	c.actions = append(c.actions, action)
 }
 
-func formatGottenArg(m Matcher, arg interface{}) string {
+func formatGottenArg(m Matcher, arg any) string {
 	got := fmt.Sprintf("%v (%T)", arg, arg)
 	if gs, ok := m.(GotFormatter); ok {
 		got = gs.Got(arg)

--- a/gomock/call_test.go
+++ b/gomock/call_test.go
@@ -47,11 +47,11 @@ type mockTestReporter struct {
 	fatalCalls int
 }
 
-func (o *mockTestReporter) Errorf(format string, args ...interface{}) {
+func (o *mockTestReporter) Errorf(format string, args ...any) {
 	o.errorCalls++
 }
 
-func (o *mockTestReporter) Fatalf(format string, args ...interface{}) {
+func (o *mockTestReporter) Fatalf(format string, args ...any) {
 	o.fatalCalls++
 }
 
@@ -88,7 +88,7 @@ func TestCall_After(t *testing.T) {
 	})
 }
 
-func prepareDoCall(doFunc, callFunc interface{}) *Call {
+func prepareDoCall(doFunc, callFunc any) *Call {
 	tr := &mockTestReporter{}
 
 	c := &Call{
@@ -101,7 +101,7 @@ func prepareDoCall(doFunc, callFunc interface{}) *Call {
 	return c
 }
 
-func prepareDoAndReturnCall(doFunc, callFunc interface{}) *Call {
+func prepareDoAndReturnCall(doFunc, callFunc any) *Call {
 	tr := &mockTestReporter{}
 
 	c := &Call{
@@ -116,9 +116,9 @@ func prepareDoAndReturnCall(doFunc, callFunc interface{}) *Call {
 
 type testCase struct {
 	description string
-	doFunc      interface{}
-	callFunc    interface{}
-	args        []interface{}
+	doFunc      any
+	callFunc    any
+	args        []any
 	expectPanic bool
 }
 
@@ -127,7 +127,7 @@ var testCases []testCase = []testCase{
 		description: "argument to Do is not a function",
 		doFunc:      "meow",
 		callFunc:    func(x int, y int) {},
-		args:        []interface{}{0, 1},
+		args:        []any{0, 1},
 		expectPanic: true,
 	}, {
 		description: "argument to Do is not a function",
@@ -135,13 +135,13 @@ var testCases []testCase = []testCase{
 		callFunc: func(x int, y int) bool {
 			return true
 		},
-		args:        []interface{}{0, 1},
+		args:        []any{0, 1},
 		expectPanic: true,
 	}, {
 		description: "number of args for Do func don't match Call func",
 		doFunc:      func(x int) {},
 		callFunc:    func(x int, y int) {},
-		args:        []interface{}{0, 1},
+		args:        []any{0, 1},
 		expectPanic: false,
 	}, {
 		description: "number of args for Do func don't match Call func",
@@ -151,13 +151,13 @@ var testCases []testCase = []testCase{
 		callFunc: func(x int, y int) bool {
 			return true
 		},
-		args:        []interface{}{0, 1},
+		args:        []any{0, 1},
 		expectPanic: false,
 	}, {
 		description: "arg type for Do func incompatible with Call func",
 		doFunc:      func(x int) {},
 		callFunc:    func(x string) {},
-		args:        []interface{}{"meow"},
+		args:        []any{"meow"},
 		expectPanic: true,
 	}, {
 		description: "arg type for Do func incompatible with Call func",
@@ -167,18 +167,18 @@ var testCases []testCase = []testCase{
 		callFunc: func(x string) bool {
 			return true
 		},
-		args:        []interface{}{"meow"},
+		args:        []any{"meow"},
 		expectPanic: true,
 	}, {
 		description: "Do func(int) Call func(int)",
 		doFunc:      func(x int) {},
 		callFunc:    func(x int) {},
-		args:        []interface{}{0},
+		args:        []any{0},
 	}, {
-		description: "Do func(int) Call func(interface{})",
+		description: "Do func(int) Call func(any)",
 		doFunc:      func(x int) {},
-		callFunc:    func(x interface{}) {},
-		args:        []interface{}{0},
+		callFunc:    func(x any) {},
+		args:        []any{0},
 	}, {
 		description: "Do func(int) bool Call func(int) bool",
 		doFunc: func(x int) bool {
@@ -187,21 +187,21 @@ var testCases []testCase = []testCase{
 		callFunc: func(x int) bool {
 			return true
 		},
-		args: []interface{}{0},
+		args: []any{0},
 	}, {
-		description: "Do func(int) bool Call func(interface{}) bool",
+		description: "Do func(int) bool Call func(any) bool",
 		doFunc: func(x int) bool {
 			return true
 		},
-		callFunc: func(x interface{}) bool {
+		callFunc: func(x any) bool {
 			return true
 		},
-		args: []interface{}{0},
+		args: []any{0},
 	}, {
 		description: "Do func(string) Call func([]byte)",
 		doFunc:      func(x string) {},
 		callFunc:    func(x []byte) {},
-		args:        []interface{}{[]byte("meow")},
+		args:        []any{[]byte("meow")},
 		expectPanic: true,
 	}, {
 		description: "Do func(string) bool Call func([]byte) bool",
@@ -211,84 +211,84 @@ var testCases []testCase = []testCase{
 		callFunc: func(x []byte) bool {
 			return true
 		},
-		args:        []interface{}{[]byte("meow")},
+		args:        []any{[]byte("meow")},
 		expectPanic: true,
 	}, {
-		description: "Do func(map[int]string) Call func(map[interface{}]int)",
+		description: "Do func(map[int]string) Call func(map[any]int)",
 		doFunc:      func(x map[int]string) {},
-		callFunc:    func(x map[interface{}]int) {},
-		args:        []interface{}{map[interface{}]int{"meow": 0}},
+		callFunc:    func(x map[any]int) {},
+		args:        []any{map[any]int{"meow": 0}},
 		expectPanic: true,
 	}, {
-		description: "Do func(map[int]string) Call func(map[interface{}]interface{})",
+		description: "Do func(map[int]string) Call func(map[any]any)",
 		doFunc:      func(x map[int]string) {},
-		callFunc:    func(x map[interface{}]interface{}) {},
-		args:        []interface{}{map[interface{}]interface{}{"meow": "meow"}},
+		callFunc:    func(x map[any]any) {},
+		args:        []any{map[any]any{"meow": "meow"}},
 		expectPanic: true,
 	}, {
-		description: "Do func(map[int]string) bool Call func(map[interface{}]int) bool",
+		description: "Do func(map[int]string) bool Call func(map[any]int) bool",
 		doFunc: func(x map[int]string) bool {
 			return true
 		},
-		callFunc: func(x map[interface{}]int) bool {
+		callFunc: func(x map[any]int) bool {
 			return true
 		},
-		args:        []interface{}{map[interface{}]int{"meow": 0}},
+		args:        []any{map[any]int{"meow": 0}},
 		expectPanic: true,
 	}, {
-		description: "Do func(map[int]string) bool Call func(map[interface{}]interface{}) bool",
+		description: "Do func(map[int]string) bool Call func(map[any]any) bool",
 		doFunc: func(x map[int]string) bool {
 			return true
 		},
-		callFunc: func(x map[interface{}]interface{}) bool {
+		callFunc: func(x map[any]any) bool {
 			return true
 		},
-		args:        []interface{}{map[interface{}]interface{}{"meow": "meow"}},
+		args:        []any{map[any]any{"meow": "meow"}},
 		expectPanic: true,
 	}, {
-		description: "Do func([]string) Call func([]interface{})",
+		description: "Do func([]string) Call func([]any)",
 		doFunc:      func(x []string) {},
-		callFunc:    func(x []interface{}) {},
-		args:        []interface{}{[]interface{}{0}},
+		callFunc:    func(x []any) {},
+		args:        []any{[]any{0}},
 		expectPanic: true,
 	}, {
 		description: "Do func([]string) Call func([]int)",
 		doFunc:      func(x []string) {},
 		callFunc:    func(x []int) {},
-		args:        []interface{}{[]int{0, 1}},
+		args:        []any{[]int{0, 1}},
 		expectPanic: true,
 	}, {
 		description: "Do func([]int) Call func([]int)",
 		doFunc:      func(x []int) {},
 		callFunc:    func(x []int) {},
-		args:        []interface{}{[]int{0, 1}},
+		args:        []any{[]int{0, 1}},
 	}, {
-		description: "Do func([]int) Call func([]interface{})",
+		description: "Do func([]int) Call func([]any)",
 		doFunc:      func(x []int) {},
-		callFunc:    func(x []interface{}) {},
-		args:        []interface{}{[]interface{}{0}},
+		callFunc:    func(x []any) {},
+		args:        []any{[]any{0}},
 		expectPanic: true,
 	}, {
-		description: "Do func([]int) Call func(...interface{})",
+		description: "Do func([]int) Call func(...any)",
 		doFunc:      func(x []int) {},
-		callFunc:    func(x ...interface{}) {},
-		args:        []interface{}{0, 1},
+		callFunc:    func(x ...any) {},
+		args:        []any{0, 1},
 		expectPanic: true,
 	}, {
 		description: "Do func([]int) Call func(...int)",
 		doFunc:      func(x []int) {},
 		callFunc:    func(x ...int) {},
-		args:        []interface{}{0, 1},
+		args:        []any{0, 1},
 		expectPanic: true,
 	}, {
-		description: "Do func([]string) bool Call func([]interface{}) bool",
+		description: "Do func([]string) bool Call func([]any) bool",
 		doFunc: func(x []string) bool {
 			return true
 		},
-		callFunc: func(x []interface{}) bool {
+		callFunc: func(x []any) bool {
 			return true
 		},
-		args:        []interface{}{[]interface{}{0}},
+		args:        []any{[]any{0}},
 		expectPanic: true,
 	}, {
 		description: "Do func([]string) bool Call func([]int) bool",
@@ -298,7 +298,7 @@ var testCases []testCase = []testCase{
 		callFunc: func(x []int) bool {
 			return true
 		},
-		args:        []interface{}{[]int{0, 1}},
+		args:        []any{[]int{0, 1}},
 		expectPanic: true,
 	}, {
 		description: "Do func([]int) bool Call func([]int) bool",
@@ -308,26 +308,26 @@ var testCases []testCase = []testCase{
 		callFunc: func(x []int) bool {
 			return true
 		},
-		args: []interface{}{[]int{0, 1}},
+		args: []any{[]int{0, 1}},
 	}, {
-		description: "Do func([]int) bool Call func([]interface{}) bool",
+		description: "Do func([]int) bool Call func([]any) bool",
 		doFunc: func(x []int) bool {
 			return true
 		},
-		callFunc: func(x []interface{}) bool {
+		callFunc: func(x []any) bool {
 			return true
 		},
-		args:        []interface{}{[]interface{}{0}},
+		args:        []any{[]any{0}},
 		expectPanic: true,
 	}, {
-		description: "Do func([]int) bool Call func(...interface{}) bool",
+		description: "Do func([]int) bool Call func(...any) bool",
 		doFunc: func(x []int) bool {
 			return true
 		},
-		callFunc: func(x ...interface{}) bool {
+		callFunc: func(x ...any) bool {
 			return true
 		},
-		args:        []interface{}{0, 1},
+		args:        []any{0, 1},
 		expectPanic: true,
 	}, {
 		description: "Do func([]int) bool Call func(...int) bool",
@@ -337,25 +337,25 @@ var testCases []testCase = []testCase{
 		callFunc: func(x ...int) bool {
 			return true
 		},
-		args:        []interface{}{0, 1},
+		args:        []any{0, 1},
 		expectPanic: true,
 	}, {
 		description: "Do func(...int) Call func([]int)",
 		doFunc:      func(x ...int) {},
 		callFunc:    func(x []int) {},
-		args:        []interface{}{[]int{0, 1}},
+		args:        []any{[]int{0, 1}},
 		expectPanic: true,
 	}, {
-		description: "Do func(...int) Call func([]interface{})",
+		description: "Do func(...int) Call func([]any)",
 		doFunc:      func(x ...int) {},
-		callFunc:    func(x []interface{}) {},
-		args:        []interface{}{[]interface{}{0, 1}},
+		callFunc:    func(x []any) {},
+		args:        []any{[]any{0, 1}},
 		expectPanic: true,
 	}, {
-		description: "Do func(...int) Call func(...interface{})",
+		description: "Do func(...int) Call func(...any)",
 		doFunc:      func(x ...int) {},
-		callFunc:    func(x ...interface{}) {},
-		args:        []interface{}{0, 1},
+		callFunc:    func(x ...any) {},
+		args:        []any{0, 1},
 	}, {
 		description: "Do func(...int) bool Call func(...int) bool",
 		doFunc: func(x ...int) bool {
@@ -364,7 +364,7 @@ var testCases []testCase = []testCase{
 		callFunc: func(x ...int) bool {
 			return true
 		},
-		args: []interface{}{0, 1},
+		args: []any{0, 1},
 	}, {
 		description: "Do func(...int) bool Call func([]int) bool",
 		doFunc: func(x ...int) bool {
@@ -373,48 +373,48 @@ var testCases []testCase = []testCase{
 		callFunc: func(x []int) bool {
 			return true
 		},
-		args:        []interface{}{[]int{0, 1}},
+		args:        []any{[]int{0, 1}},
 		expectPanic: true,
 	}, {
-		description: "Do func(...int) bool Call func([]interface{}) bool",
+		description: "Do func(...int) bool Call func([]any) bool",
 		doFunc: func(x ...int) bool {
 			return true
 		},
-		callFunc: func(x []interface{}) bool {
+		callFunc: func(x []any) bool {
 			return true
 		},
-		args:        []interface{}{[]interface{}{0, 1}},
+		args:        []any{[]any{0, 1}},
 		expectPanic: true,
 	}, {
-		description: "Do func(...int) bool Call func(...interface{}) bool",
+		description: "Do func(...int) bool Call func(...any) bool",
 		doFunc: func(x ...int) bool {
 			return true
 		},
-		callFunc: func(x ...interface{}) bool {
+		callFunc: func(x ...any) bool {
 			return true
 		},
-		args: []interface{}{0, 1},
+		args: []any{0, 1},
 	}, {
 		description: "Do func(...int) Call func(...int)",
 		doFunc:      func(x ...int) {},
 		callFunc:    func(x ...int) {},
-		args:        []interface{}{0, 1},
+		args:        []any{0, 1},
 	}, {
 		description: "Do func(foo); foo implements interface X Call func(interface X)",
 		doFunc:      func(x foo) {},
 		callFunc:    func(x fmt.Stringer) {},
-		args:        []interface{}{foo{}},
+		args:        []any{foo{}},
 	}, {
 		description: "Do func(b); b does not implement interface X Call func(interface X)",
 		doFunc:      func(x b) {},
 		callFunc:    func(x fmt.Stringer) {},
-		args:        []interface{}{foo{}},
+		args:        []any{foo{}},
 		expectPanic: true,
 	}, {
 		description: "Do func(b) Call func(a); a and b are not aliases",
 		doFunc:      func(x b) {},
 		callFunc:    func(x a) {},
-		args:        []interface{}{a{}},
+		args:        []any{a{}},
 		expectPanic: true,
 	}, {
 		description: "Do func(foo) bool; foo implements interface X Call func(interface X) bool",
@@ -424,7 +424,7 @@ var testCases []testCase = []testCase{
 		callFunc: func(x fmt.Stringer) bool {
 			return true
 		},
-		args: []interface{}{foo{}},
+		args: []any{foo{}},
 	}, {
 		description: "Do func(b) bool; b does not implement interface X Call func(interface X) bool",
 		doFunc: func(x b) bool {
@@ -433,7 +433,7 @@ var testCases []testCase = []testCase{
 		callFunc: func(x fmt.Stringer) bool {
 			return true
 		},
-		args:        []interface{}{foo{}},
+		args:        []any{foo{}},
 		expectPanic: true,
 	}, {
 		description: "Do func(b) bool Call func(a) bool; a and b are not aliases",
@@ -443,7 +443,7 @@ var testCases []testCase = []testCase{
 		callFunc: func(x a) bool {
 			return true
 		},
-		args:        []interface{}{a{}},
+		args:        []any{a{}},
 		expectPanic: true,
 	}, {
 		description: "Do func(bool) b Call func(bool) a; a and b are not aliases",
@@ -453,7 +453,7 @@ var testCases []testCase = []testCase{
 		callFunc: func(x bool) a {
 			return a{}
 		},
-		args: []interface{}{true},
+		args: []any{true},
 	},
 }
 
@@ -485,36 +485,36 @@ func TestCall_Do_NumArgValidation(t *testing.T) {
 	tests := []struct {
 		name       string
 		methodType reflect.Type
-		doFn       interface{}
-		args       []interface{}
+		doFn       any
+		args       []any
 		wantErr    bool
 	}{
 		{
 			name:       "too few",
 			methodType: reflect.TypeOf(func(one, two string) {}),
 			doFn:       func(one string) {},
-			args:       []interface{}{"too", "few"},
+			args:       []any{"too", "few"},
 			wantErr:    true,
 		},
 		{
 			name:       "too many",
 			methodType: reflect.TypeOf(func(one, two string) {}),
 			doFn:       func(one, two, three string) {},
-			args:       []interface{}{"too", "few"},
+			args:       []any{"too", "few"},
 			wantErr:    true,
 		},
 		{
 			name:       "just right",
 			methodType: reflect.TypeOf(func(one, two string) {}),
 			doFn:       func(one string, two string) {},
-			args:       []interface{}{"just", "right"},
+			args:       []any{"just", "right"},
 			wantErr:    false,
 		},
 		{
 			name:       "variadic",
 			methodType: reflect.TypeOf(func(one, two string) {}),
-			doFn:       func(args ...interface{}) {},
-			args:       []interface{}{"just", "right"},
+			doFn:       func(args ...any) {},
+			args:       []any{"just", "right"},
 			wantErr:    true,
 		},
 	}
@@ -541,36 +541,36 @@ func TestCall_DoAndReturn_NumArgValidation(t *testing.T) {
 	tests := []struct {
 		name       string
 		methodType reflect.Type
-		doFn       interface{}
-		args       []interface{}
+		doFn       any
+		args       []any
 		wantErr    bool
 	}{
 		{
 			name:       "too few",
 			methodType: reflect.TypeOf(func(one, two string) string { return "" }),
 			doFn:       func(one string) {},
-			args:       []interface{}{"too", "few"},
+			args:       []any{"too", "few"},
 			wantErr:    true,
 		},
 		{
 			name:       "too many",
 			methodType: reflect.TypeOf(func(one, two string) string { return "" }),
 			doFn:       func(one, two, three string) string { return "" },
-			args:       []interface{}{"too", "few"},
+			args:       []any{"too", "few"},
 			wantErr:    true,
 		},
 		{
 			name:       "just right",
 			methodType: reflect.TypeOf(func(one, two string) string { return "" }),
 			doFn:       func(one string, two string) string { return "" },
-			args:       []interface{}{"just", "right"},
+			args:       []any{"just", "right"},
 			wantErr:    false,
 		},
 		{
 			name:       "variadic",
 			methodType: reflect.TypeOf(func(one, two string) {}),
-			doFn:       func(args ...interface{}) string { return "" },
-			args:       []interface{}{"just", "right"},
+			doFn:       func(args ...any) string { return "" },
+			args:       []any{"just", "right"},
 			wantErr:    true,
 		},
 	}

--- a/gomock/callset.go
+++ b/gomock/callset.go
@@ -35,7 +35,7 @@ type callSet struct {
 
 // callSetKey is the key in the maps in callSet
 type callSetKey struct {
-	receiver interface{}
+	receiver any
 	fname    string
 }
 
@@ -50,7 +50,7 @@ func newCallSet() *callSet {
 func newOverridableCallSet() *callSet {
 	return &callSet{
 		expected:      make(map[callSetKey][]*Call),
-		expectedMu: &sync.Mutex{},
+		expectedMu:    &sync.Mutex{},
 		exhausted:     make(map[callSetKey][]*Call),
 		allowOverride: true,
 	}
@@ -93,7 +93,7 @@ func (cs callSet) Remove(call *Call) {
 }
 
 // FindMatch searches for a matching call. Returns error with explanation message if no call matched.
-func (cs callSet) FindMatch(receiver interface{}, method string, args []interface{}) (*Call, error) {
+func (cs callSet) FindMatch(receiver any, method string, args []any) (*Call, error) {
 	key := callSetKey{receiver, method}
 
 	cs.expectedMu.Lock()

--- a/gomock/callset_test.go
+++ b/gomock/callset_test.go
@@ -25,7 +25,7 @@ func (receiverType) Func() {}
 
 func TestCallSetAdd(t *testing.T) {
 	method := "TestMethod"
-	var receiver interface{} = "TestReceiver"
+	var receiver any = "TestReceiver"
 	cs := newCallSet()
 
 	numCalls := 10
@@ -33,7 +33,7 @@ func TestCallSetAdd(t *testing.T) {
 		cs.Add(newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func)))
 	}
 
-	call, err := cs.FindMatch(receiver, method, []interface{}{})
+	call, err := cs.FindMatch(receiver, method, []any{})
 	if err != nil {
 		t.Fatalf("FindMatch: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestCallSetAdd(t *testing.T) {
 
 func TestCallSetAdd_WhenOverridable_ClearsPreviousExpectedAndExhausted(t *testing.T) {
 	method := "TestMethod"
-	var receiver interface{} = "TestReceiver"
+	var receiver any = "TestReceiver"
 	cs := newOverridableCallSet()
 
 	cs.Add(newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func)))
@@ -62,7 +62,7 @@ func TestCallSetAdd_WhenOverridable_ClearsPreviousExpectedAndExhausted(t *testin
 
 func TestCallSetRemove(t *testing.T) {
 	method := "TestMethod"
-	var receiver interface{} = "TestReceiver"
+	var receiver any = "TestReceiver"
 
 	cs := newCallSet()
 	ourCalls := []*Call{}
@@ -96,9 +96,9 @@ func TestCallSetRemove(t *testing.T) {
 func TestCallSetFindMatch(t *testing.T) {
 	t.Run("call is exhausted", func(t *testing.T) {
 		cs := newCallSet()
-		var receiver interface{} = "TestReceiver"
+		var receiver any = "TestReceiver"
 		method := "TestMethod"
-		args := []interface{}{}
+		args := []any{}
 
 		c1 := newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func))
 		cs.exhausted = map[callSetKey][]*Call{

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -25,8 +25,8 @@ import (
 // A TestReporter is something that can be used to report test failures.  It
 // is satisfied by the standard library's *testing.T.
 type TestReporter interface {
-	Errorf(format string, args ...interface{})
-	Fatalf(format string, args ...interface{})
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
 }
 
 // TestHelper is a TestReporter that has the Helper method.  It is satisfied
@@ -130,10 +130,10 @@ type cancelReporter struct {
 	cancel func()
 }
 
-func (r *cancelReporter) Errorf(format string, args ...interface{}) {
+func (r *cancelReporter) Errorf(format string, args ...any) {
 	r.t.Errorf(format, args...)
 }
-func (r *cancelReporter) Fatalf(format string, args ...interface{}) {
+func (r *cancelReporter) Fatalf(format string, args ...any) {
 	defer r.cancel()
 	r.t.Fatalf(format, args...)
 }
@@ -158,17 +158,17 @@ type nopTestHelper struct {
 	t TestReporter
 }
 
-func (h *nopTestHelper) Errorf(format string, args ...interface{}) {
+func (h *nopTestHelper) Errorf(format string, args ...any) {
 	h.t.Errorf(format, args...)
 }
-func (h *nopTestHelper) Fatalf(format string, args ...interface{}) {
+func (h *nopTestHelper) Fatalf(format string, args ...any) {
 	h.t.Fatalf(format, args...)
 }
 
 func (h nopTestHelper) Helper() {}
 
 // RecordCall is called by a mock. It should not be called by user code.
-func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...interface{}) *Call {
+func (ctrl *Controller) RecordCall(receiver any, method string, args ...any) *Call {
 	ctrl.T.Helper()
 
 	recv := reflect.ValueOf(receiver)
@@ -182,7 +182,7 @@ func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...
 }
 
 // RecordCallWithMethodType is called by a mock. It should not be called by user code.
-func (ctrl *Controller) RecordCallWithMethodType(receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
+func (ctrl *Controller) RecordCallWithMethodType(receiver any, method string, methodType reflect.Type, args ...any) *Call {
 	ctrl.T.Helper()
 
 	call := newCall(ctrl.T, receiver, method, methodType, args...)
@@ -195,11 +195,11 @@ func (ctrl *Controller) RecordCallWithMethodType(receiver interface{}, method st
 }
 
 // Call is called by a mock. It should not be called by user code.
-func (ctrl *Controller) Call(receiver interface{}, method string, args ...interface{}) []interface{} {
+func (ctrl *Controller) Call(receiver any, method string, args ...any) []any {
 	ctrl.T.Helper()
 
 	// Nest this code so we can use defer to make sure the lock is released.
-	actions := func() []func([]interface{}) []interface{} {
+	actions := func() []func([]any) []any {
 		ctrl.T.Helper()
 		ctrl.mu.Lock()
 		defer ctrl.mu.Unlock()
@@ -228,7 +228,7 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 		return actions
 	}()
 
-	var rets []interface{}
+	var rets []any
 	for _, action := range actions {
 		if r := action(args); r != nil {
 			rets = r
@@ -257,7 +257,7 @@ func (ctrl *Controller) Satisfied() bool {
 	return ctrl.expectedCalls.Satisfied()
 }
 
-func (ctrl *Controller) finish(cleanup bool, panicErr interface{}) {
+func (ctrl *Controller) finish(cleanup bool, panicErr any) {
 	ctrl.T.Helper()
 
 	ctrl.mu.Lock()

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -107,20 +107,20 @@ func (e *ErrorReporter) recoverUnexpectedFatal() {
 	}
 }
 
-func (e *ErrorReporter) Log(args ...interface{}) {
+func (e *ErrorReporter) Log(args ...any) {
 	e.log = append(e.log, fmt.Sprint(args...))
 }
 
-func (e *ErrorReporter) Logf(format string, args ...interface{}) {
+func (e *ErrorReporter) Logf(format string, args ...any) {
 	e.log = append(e.log, fmt.Sprintf(format, args...))
 }
 
-func (e *ErrorReporter) Errorf(format string, args ...interface{}) {
+func (e *ErrorReporter) Errorf(format string, args ...any) {
 	e.Logf(format, args...)
 	e.failed = true
 }
 
-func (e *ErrorReporter) Fatalf(format string, args ...interface{}) {
+func (e *ErrorReporter) Fatalf(format string, args ...any) {
 	e.Logf(format, args...)
 	e.failed = true
 	panic(&e.fatalToken)
@@ -158,10 +158,10 @@ func (s *Subject) ActOnTestStructMethod(arg TestStruct, arg1 int) int {
 	return 0
 }
 
-func (s *Subject) SetArgMethod(sliceArg []byte, ptrArg *int, mapArg map[interface{}]interface{}) {}
-func (s *Subject) SetArgMethodInterface(sliceArg, ptrArg, mapArg interface{})                    {}
+func (s *Subject) SetArgMethod(sliceArg []byte, ptrArg *int, mapArg map[any]any) {}
+func (s *Subject) SetArgMethodInterface(sliceArg, ptrArg, mapArg any)            {}
 
-func assertEqual(t *testing.T, expected interface{}, actual interface{}) {
+func assertEqual(t *testing.T, expected any, actual any) {
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expected %+v, but got %+v", expected, actual)
 	}
@@ -360,7 +360,7 @@ func TestUnexpectedArgValue_GotFormatter(t *testing.T) {
 		"ActOnTestStructMethod",
 		expectedArg0,
 		gomock.GotFormatterAdapter(
-			gomock.GotFormatterFunc(func(i interface{}) string {
+			gomock.GotFormatterFunc(func(i any) string {
 				// Leading 0s
 				return fmt.Sprintf("%02d", i)
 			}),
@@ -572,7 +572,7 @@ func TestSetArgSlice(t *testing.T) {
 	ctrl.Call(subject, "SetArgMethodInterface", in, nil, nil)
 
 	if !reflect.DeepEqual(in, set) {
-		t.Error("Expected SetArg() to modify input slice argument as interface{}")
+		t.Error("Expected SetArg() to modify input slice argument as any")
 	}
 
 	ctrl.Finish()
@@ -582,8 +582,8 @@ func TestSetArgMap(t *testing.T) {
 	_, ctrl := createFixtures(t)
 	subject := new(Subject)
 
-	var in = map[interface{}]interface{}{"int": 1, "string": "random string", 1: "1", 0: 0}
-	var set = map[interface{}]interface{}{"int": 2, 1: "2", 2: 100}
+	var in = map[any]any{"int": 1, "string": "random string", 1: "1", 0: 0}
+	var set = map[any]any{"int": 2, 1: "2", 2: 100}
 	ctrl.RecordCall(subject, "SetArgMethod", nil, nil, in).SetArg(2, set)
 	ctrl.Call(subject, "SetArgMethod", nil, nil, in)
 
@@ -595,7 +595,7 @@ func TestSetArgMap(t *testing.T) {
 	ctrl.Call(subject, "SetArgMethodInterface", nil, nil, in)
 
 	if !reflect.DeepEqual(in, set) {
-		t.Error("Expected SetArg() to modify input map argument as interface{}")
+		t.Error("Expected SetArg() to modify input map argument as any")
 	}
 
 	ctrl.Finish()
@@ -618,7 +618,7 @@ func TestSetArgPtr(t *testing.T) {
 	ctrl.Call(subject, "SetArgMethodInterface", nil, &in, nil)
 
 	if in != set {
-		t.Error("Expected SetArg() to modify value pointed to by argument as interface{}")
+		t.Error("Expected SetArg() to modify value pointed to by argument as any")
 	}
 	ctrl.Finish()
 }
@@ -633,12 +633,12 @@ func TestReturn(t *testing.T) {
 
 	assertEqual(
 		t,
-		[]interface{}{0},
+		[]any{0},
 		ctrl.Call(subject, "FooMethod", "zero"))
 
 	assertEqual(
 		t,
-		[]interface{}{5},
+		[]any{5},
 		ctrl.Call(subject, "FooMethod", "five"))
 	ctrl.Finish()
 }
@@ -765,7 +765,7 @@ func TestVariadicMatchingWithSlice(t *testing.T) {
 
 			s := new(Subject)
 			ctrl.RecordCall(s, "VariadicMethod", 1, tc)
-			args := make([]interface{}, len(tc)+1)
+			args := make([]any, len(tc)+1)
 			args[0] = 1
 			for i, arg := range tc {
 				args[i+1] = arg
@@ -786,7 +786,7 @@ func TestVariadicArgumentsGotFormatter(t *testing.T) {
 		s,
 		"VariadicMethod",
 		gomock.GotFormatterAdapter(
-			gomock.GotFormatterFunc(func(i interface{}) string {
+			gomock.GotFormatterFunc(func(i any) string {
 				return fmt.Sprintf("test{%v}", i)
 			}),
 			gomock.Eq(0),
@@ -811,7 +811,7 @@ func TestVariadicArgumentsGotFormatterTooManyArgsFailure(t *testing.T) {
 		"VariadicMethod",
 		0,
 		gomock.GotFormatterAdapter(
-			gomock.GotFormatterFunc(func(i interface{}) string {
+			gomock.GotFormatterFunc(func(i any) string {
 				return fmt.Sprintf("test{%v}", i)
 			}),
 			gomock.Eq("1"),

--- a/gomock/example_test.go
+++ b/gomock/example_test.go
@@ -38,7 +38,7 @@ func ExampleCall_DoAndReturn_captureArguments() {
 	var s string
 
 	mockIndex.EXPECT().Bar(gomock.AssignableToTypeOf(s)).DoAndReturn(
-		func(arg string) interface{} {
+		func(arg string) any {
 			s = arg
 			return "I'm sleepy"
 		},
@@ -56,7 +56,7 @@ func ExampleCall_DoAndReturn_withOverridableExpectations() {
 	var s string
 
 	mockIndex.EXPECT().Bar(gomock.AssignableToTypeOf(s)).DoAndReturn(
-		func(arg string) interface{} {
+		func(arg string) any {
 			s = arg
 			return "I'm sleepy"
 		},

--- a/gomock/internal/mock_gomock/mock_matcher.go
+++ b/gomock/internal/mock_gomock/mock_matcher.go
@@ -38,7 +38,7 @@ func (m *MockMatcher) EXPECT() *MockMatcherMockRecorder {
 }
 
 // Matches mocks base method.
-func (m *MockMatcher) Matches(arg0 interface{}) bool {
+func (m *MockMatcher) Matches(arg0 any) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Matches", arg0)
 	ret0, _ := ret[0].(bool)
@@ -46,7 +46,7 @@ func (m *MockMatcher) Matches(arg0 interface{}) bool {
 }
 
 // Matches indicates an expected call of Matches.
-func (mr *MockMatcherMockRecorder) Matches(arg0 interface{}) *gomock.Call {
+func (mr *MockMatcherMockRecorder) Matches(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Matches", reflect.TypeOf((*MockMatcher)(nil).Matches), arg0)
 }

--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -29,7 +29,7 @@ import (
 type A []string
 
 func TestMatchers(t *testing.T) {
-	type e interface{}
+	type e any
 	tests := []struct {
 		name    string
 		matcher gomock.Matcher
@@ -148,8 +148,8 @@ func TestAssignableToTypeOfMatcher(t *testing.T) {
 func TestInAnyOrder(t *testing.T) {
 	tests := []struct {
 		name      string
-		wanted    interface{}
-		given     interface{}
+		wanted    any
+		given     any
 		wantMatch bool
 	}{
 		{

--- a/gomock/mock_test.go
+++ b/gomock/mock_test.go
@@ -46,7 +46,7 @@ func (m *MockFoo) Bar(arg0 string) string {
 }
 
 // Bar indicates an expected call of Bar.
-func (mr *MockFooMockRecorder) Bar(arg0 interface{}) *gomock.Call {
+func (mr *MockFooMockRecorder) Bar(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bar", reflect.TypeOf((*MockFoo)(nil).Bar), arg0)
 }

--- a/mockgen/generic_go118.go
+++ b/mockgen/generic_go118.go
@@ -65,7 +65,7 @@ func (p *fileParser) parseGenericType(pkg string, typ ast.Expr, tps map[string]m
 	return nil, nil
 }
 
-func getIdentTypeParams(decl interface{}) string {
+func getIdentTypeParams(decl any) string {
 	if decl == nil {
 		return ""
 	}

--- a/mockgen/generic_notgo118.go
+++ b/mockgen/generic_notgo118.go
@@ -32,7 +32,7 @@ func (p *fileParser) parseGenericType(pkg string, typ ast.Expr, tps map[string]m
 	return nil, nil
 }
 
-func getIdentTypeParams(decl interface{}) string {
+func getIdentTypeParams(decl any) string {
 	return ""
 }
 

--- a/mockgen/internal/tests/aux_imports_embedded_interface/faux/faux.go
+++ b/mockgen/internal/tests/aux_imports_embedded_interface/faux/faux.go
@@ -6,6 +6,6 @@ type Foreign interface {
 	error
 }
 
-type Embedded interface{}
+type Embedded any
 
-type Return interface{}
+type Return any

--- a/mockgen/internal/tests/copyright_file/input.go
+++ b/mockgen/internal/tests/copyright_file/input.go
@@ -2,4 +2,4 @@ package empty_interface
 
 //go:generate mockgen -package empty_interface -destination mock.go -source input.go -copyright_file=mock_copyright_header
 
-type Empty interface{}
+type Empty any

--- a/mockgen/internal/tests/empty_interface/input.go
+++ b/mockgen/internal/tests/empty_interface/input.go
@@ -2,4 +2,4 @@ package empty_interface
 
 //go:generate mockgen -package empty_interface -destination mock.go -source input.go
 
-type Empty interface{}
+type Empty any

--- a/mockgen/internal/tests/extra_import/mock.go
+++ b/mockgen/internal/tests/extra_import/mock.go
@@ -44,7 +44,7 @@ func (m *MockFoo) Bar(arg0 []string, arg1 chan<- Message) {
 }
 
 // Bar indicates an expected call of Bar.
-func (mr *MockFooMockRecorder) Bar(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockFooMockRecorder) Bar(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bar", reflect.TypeOf((*MockFoo)(nil).Bar), arg0, arg1)
 }

--- a/mockgen/internal/tests/generated_identifier_conflict/bugreport_mock.go
+++ b/mockgen/internal/tests/generated_identifier_conflict/bugreport_mock.go
@@ -44,7 +44,7 @@ func (m_2 *MockExample) Method(_m, _mr, m, mr int) {
 }
 
 // Method indicates an expected call of Method.
-func (mr_2 *MockExampleMockRecorder) Method(_m, _mr, m, mr interface{}) *gomock.Call {
+func (mr_2 *MockExampleMockRecorder) Method(_m, _mr, m, mr any) *gomock.Call {
 	mr_2.mock.ctrl.T.Helper()
 	return mr_2.mock.ctrl.RecordCallWithMethodType(mr_2.mock, "Method", reflect.TypeOf((*MockExample)(nil).Method), _m, _mr, m, mr)
 }
@@ -52,7 +52,7 @@ func (mr_2 *MockExampleMockRecorder) Method(_m, _mr, m, mr interface{}) *gomock.
 // VarargMethod mocks base method.
 func (m *MockExample) VarargMethod(_s, _x, a, ret int, varargs ...int) {
 	m.ctrl.T.Helper()
-	varargs_2 := []interface{}{_s, _x, a, ret}
+	varargs_2 := []any{_s, _x, a, ret}
 	for _, a_2 := range varargs {
 		varargs_2 = append(varargs_2, a_2)
 	}
@@ -60,8 +60,8 @@ func (m *MockExample) VarargMethod(_s, _x, a, ret int, varargs ...int) {
 }
 
 // VarargMethod indicates an expected call of VarargMethod.
-func (mr *MockExampleMockRecorder) VarargMethod(_s, _x, a, ret interface{}, varargs ...interface{}) *gomock.Call {
+func (mr *MockExampleMockRecorder) VarargMethod(_s, _x, a, ret any, varargs ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs_2 := append([]interface{}{_s, _x, a, ret}, varargs...)
+	varargs_2 := append([]any{_s, _x, a, ret}, varargs...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VarargMethod", reflect.TypeOf((*MockExample)(nil).VarargMethod), varargs_2...)
 }

--- a/mockgen/internal/tests/generics/generics.go
+++ b/mockgen/internal/tests/generics/generics.go
@@ -34,7 +34,7 @@ type Foo[T any, R any] struct{}
 
 type Baz[T any] struct{}
 
-type Iface[T any] interface{}
+type Iface[T any] any
 
 type StructType struct{}
 

--- a/mockgen/internal/tests/generics/other/other.go
+++ b/mockgen/internal/tests/generics/other/other.go
@@ -8,7 +8,7 @@ type Three struct{}
 
 type Four struct{}
 
-type Five interface{}
+type Five any
 
 type Either[T, R, K, V any] interface {
 	First() T

--- a/mockgen/internal/tests/generics/source/mock_external_mock.go
+++ b/mockgen/internal/tests/generics/source/mock_external_mock.go
@@ -46,7 +46,7 @@ func (m *MockExternalConstraint[I, F]) Eight(arg0 F) other.Two[I, F] {
 }
 
 // Eight indicates an expected call of Eight.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Eight(arg0 interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Eight(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eight", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Eight), arg0)
 }
@@ -74,7 +74,7 @@ func (m *MockExternalConstraint[I, F]) Five(arg0 I) generics.Baz[F] {
 }
 
 // Five indicates an expected call of Five.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Five(arg0 interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Five(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Five", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Five), arg0)
 }
@@ -88,7 +88,7 @@ func (m *MockExternalConstraint[I, F]) Four(arg0 I) generics.Foo[I, F] {
 }
 
 // Four indicates an expected call of Four.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Four(arg0 interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Four(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Four", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Four), arg0)
 }
@@ -100,7 +100,7 @@ func (m *MockExternalConstraint[I, F]) Nine(arg0 generics.Iface[I]) {
 }
 
 // Nine indicates an expected call of Nine.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Nine(arg0 interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Nine(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nine", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Nine), arg0)
 }
@@ -114,7 +114,7 @@ func (m *MockExternalConstraint[I, F]) One(arg0 string) string {
 }
 
 // One indicates an expected call of One.
-func (mr *MockExternalConstraintMockRecorder[I, F]) One(arg0 interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) One(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "One", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).One), arg0)
 }
@@ -128,7 +128,7 @@ func (m *MockExternalConstraint[I, F]) Seven(arg0 I) other.One[I] {
 }
 
 // Seven indicates an expected call of Seven.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Seven(arg0 interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Seven(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seven", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Seven), arg0)
 }
@@ -142,7 +142,7 @@ func (m *MockExternalConstraint[I, F]) Six(arg0 I) *generics.Baz[F] {
 }
 
 // Six indicates an expected call of Six.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Six(arg0 interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Six(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Six", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Six), arg0)
 }
@@ -154,7 +154,7 @@ func (m *MockExternalConstraint[I, F]) Ten(arg0 *I) {
 }
 
 // Ten indicates an expected call of Ten.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Ten(arg0 interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Ten(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ten", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Ten), arg0)
 }
@@ -162,7 +162,7 @@ func (mr *MockExternalConstraintMockRecorder[I, F]) Ten(arg0 interface{}) *gomoc
 // Thirteen mocks base method.
 func (m *MockExternalConstraint[I, F]) Thirteen(arg0 ...I) *F {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{}
+	varargs := []any{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
 	}
@@ -172,7 +172,7 @@ func (m *MockExternalConstraint[I, F]) Thirteen(arg0 ...I) *F {
 }
 
 // Thirteen indicates an expected call of Thirteen.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Thirteen(arg0 ...interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Thirteen(arg0 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Thirteen", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Thirteen), arg0...)
 }
@@ -186,7 +186,7 @@ func (m *MockExternalConstraint[I, F]) Three(arg0 I) F {
 }
 
 // Three indicates an expected call of Three.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Three(arg0 interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Three(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Three", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Three), arg0)
 }
@@ -200,7 +200,7 @@ func (m *MockExternalConstraint[I, F]) Twelve(ctx context.Context) <-chan []I {
 }
 
 // Twelve indicates an expected call of Twelve.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Twelve(ctx interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Twelve(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Twelve", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Twelve), ctx)
 }
@@ -214,7 +214,7 @@ func (m *MockExternalConstraint[I, F]) Two(arg0 I) string {
 }
 
 // Two indicates an expected call of Two.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Two(arg0 interface{}) *gomock.Call {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Two(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Two", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Two), arg0)
 }
@@ -251,7 +251,7 @@ func (m *MockEmbeddingIface[T, R]) Eight(arg0 R) other.Two[T, R] {
 }
 
 // Eight indicates an expected call of Eight.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Eight(arg0 interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Eight(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eight", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Eight), arg0)
 }
@@ -293,7 +293,7 @@ func (m *MockEmbeddingIface[T, R]) Five(arg0 T) generics.Baz[R] {
 }
 
 // Five indicates an expected call of Five.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Five(arg0 interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Five(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Five", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Five), arg0)
 }
@@ -307,7 +307,7 @@ func (m *MockEmbeddingIface[T, R]) Four(arg0 T) generics.Foo[T, R] {
 }
 
 // Four indicates an expected call of Four.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Four(arg0 interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Four(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Four", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Four), arg0)
 }
@@ -347,7 +347,7 @@ func (m *MockEmbeddingIface[T, R]) Nine(arg0 generics.Iface[T]) {
 }
 
 // Nine indicates an expected call of Nine.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Nine(arg0 interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Nine(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nine", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Nine), arg0)
 }
@@ -361,7 +361,7 @@ func (m *MockEmbeddingIface[T, R]) One(arg0 string) string {
 }
 
 // One indicates an expected call of One.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) One(arg0 interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) One(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "One", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).One), arg0)
 }
@@ -376,7 +376,7 @@ func (m *MockEmbeddingIface[T, R]) Read(p []byte) (int, error) {
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Read(p interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Read(p any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Read), p)
 }
@@ -404,7 +404,7 @@ func (m *MockEmbeddingIface[T, R]) Seven(arg0 T) other.One[T] {
 }
 
 // Seven indicates an expected call of Seven.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Seven(arg0 interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Seven(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seven", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Seven), arg0)
 }
@@ -418,7 +418,7 @@ func (m *MockEmbeddingIface[T, R]) Six(arg0 T) *generics.Baz[R] {
 }
 
 // Six indicates an expected call of Six.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Six(arg0 interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Six(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Six", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Six), arg0)
 }
@@ -430,7 +430,7 @@ func (m *MockEmbeddingIface[T, R]) Ten(arg0 *T) {
 }
 
 // Ten indicates an expected call of Ten.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Ten(arg0 interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Ten(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ten", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Ten), arg0)
 }
@@ -452,7 +452,7 @@ func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Third() *gomock.Call {
 // Thirteen mocks base method.
 func (m *MockEmbeddingIface[T, R]) Thirteen(arg0 ...T) *R {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{}
+	varargs := []any{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
 	}
@@ -462,7 +462,7 @@ func (m *MockEmbeddingIface[T, R]) Thirteen(arg0 ...T) *R {
 }
 
 // Thirteen indicates an expected call of Thirteen.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Thirteen(arg0 ...interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Thirteen(arg0 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Thirteen", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Thirteen), arg0...)
 }
@@ -476,7 +476,7 @@ func (m *MockEmbeddingIface[T, R]) Three(arg0 T) R {
 }
 
 // Three indicates an expected call of Three.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Three(arg0 interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Three(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Three", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Three), arg0)
 }
@@ -490,7 +490,7 @@ func (m *MockEmbeddingIface[T, R]) Twelve(ctx context.Context) <-chan []T {
 }
 
 // Twelve indicates an expected call of Twelve.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Twelve(ctx interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Twelve(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Twelve", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Twelve), ctx)
 }
@@ -504,7 +504,7 @@ func (m *MockEmbeddingIface[T, R]) Two(arg0 T) string {
 }
 
 // Two indicates an expected call of Two.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Two(arg0 interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Two(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Two", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Two), arg0)
 }
@@ -518,7 +518,7 @@ func (m *MockEmbeddingIface[T, R]) Water(arg0 generics.Generator[T]) []generics.
 }
 
 // Water indicates an expected call of Water.
-func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Water(arg0 interface{}) *gomock.Call {
+func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Water(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Water", reflect.TypeOf((*MockEmbeddingIface[T, R])(nil).Water), arg0)
 }
@@ -592,7 +592,7 @@ func (m *MockGroup[T]) Join(ctx context.Context) []T {
 }
 
 // Join indicates an expected call of Join.
-func (mr *MockGroupMockRecorder[T]) Join(ctx interface{}) *gomock.Call {
+func (mr *MockGroupMockRecorder[T]) Join(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Join", reflect.TypeOf((*MockGroup[T])(nil).Join), ctx)
 }

--- a/mockgen/internal/tests/generics/source/mock_generics_mock.go
+++ b/mockgen/internal/tests/generics/source/mock_generics_mock.go
@@ -45,7 +45,7 @@ func (m *MockBar[T, R]) Eight(arg0 T) other.Two[T, R] {
 }
 
 // Eight indicates an expected call of Eight.
-func (mr *MockBarMockRecorder[T, R]) Eight(arg0 interface{}) *gomock.Call {
+func (mr *MockBarMockRecorder[T, R]) Eight(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eight", reflect.TypeOf((*MockBar[T, R])(nil).Eight), arg0)
 }
@@ -104,7 +104,7 @@ func (m *MockBar[T, R]) Five(arg0 T) generics.Baz[T] {
 }
 
 // Five indicates an expected call of Five.
-func (mr *MockBarMockRecorder[T, R]) Five(arg0 interface{}) *gomock.Call {
+func (mr *MockBarMockRecorder[T, R]) Five(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Five", reflect.TypeOf((*MockBar[T, R])(nil).Five), arg0)
 }
@@ -118,7 +118,7 @@ func (m *MockBar[T, R]) Four(arg0 T) generics.Foo[T, R] {
 }
 
 // Four indicates an expected call of Four.
-func (mr *MockBarMockRecorder[T, R]) Four(arg0 interface{}) *gomock.Call {
+func (mr *MockBarMockRecorder[T, R]) Four(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Four", reflect.TypeOf((*MockBar[T, R])(nil).Four), arg0)
 }
@@ -145,7 +145,7 @@ func (m *MockBar[T, R]) Nine(arg0 generics.Iface[T]) {
 }
 
 // Nine indicates an expected call of Nine.
-func (mr *MockBarMockRecorder[T, R]) Nine(arg0 interface{}) *gomock.Call {
+func (mr *MockBarMockRecorder[T, R]) Nine(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nine", reflect.TypeOf((*MockBar[T, R])(nil).Nine), arg0)
 }
@@ -173,7 +173,7 @@ func (m *MockBar[T, R]) One(arg0 string) string {
 }
 
 // One indicates an expected call of One.
-func (mr *MockBarMockRecorder[T, R]) One(arg0 interface{}) *gomock.Call {
+func (mr *MockBarMockRecorder[T, R]) One(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "One", reflect.TypeOf((*MockBar[T, R])(nil).One), arg0)
 }
@@ -187,7 +187,7 @@ func (m *MockBar[T, R]) Seven(arg0 T) other.One[T] {
 }
 
 // Seven indicates an expected call of Seven.
-func (mr *MockBarMockRecorder[T, R]) Seven(arg0 interface{}) *gomock.Call {
+func (mr *MockBarMockRecorder[T, R]) Seven(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seven", reflect.TypeOf((*MockBar[T, R])(nil).Seven), arg0)
 }
@@ -216,7 +216,7 @@ func (m *MockBar[T, R]) Six(arg0 T) *generics.Baz[T] {
 }
 
 // Six indicates an expected call of Six.
-func (mr *MockBarMockRecorder[T, R]) Six(arg0 interface{}) *gomock.Call {
+func (mr *MockBarMockRecorder[T, R]) Six(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Six", reflect.TypeOf((*MockBar[T, R])(nil).Six), arg0)
 }
@@ -243,7 +243,7 @@ func (m *MockBar[T, R]) Ten(arg0 *T) {
 }
 
 // Ten indicates an expected call of Ten.
-func (mr *MockBarMockRecorder[T, R]) Ten(arg0 interface{}) *gomock.Call {
+func (mr *MockBarMockRecorder[T, R]) Ten(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ten", reflect.TypeOf((*MockBar[T, R])(nil).Ten), arg0)
 }
@@ -272,7 +272,7 @@ func (m *MockBar[T, R]) Three(arg0 T) R {
 }
 
 // Three indicates an expected call of Three.
-func (mr *MockBarMockRecorder[T, R]) Three(arg0 interface{}) *gomock.Call {
+func (mr *MockBarMockRecorder[T, R]) Three(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Three", reflect.TypeOf((*MockBar[T, R])(nil).Three), arg0)
 }
@@ -301,7 +301,7 @@ func (m *MockBar[T, R]) Two(arg0 T) string {
 }
 
 // Two indicates an expected call of Two.
-func (mr *MockBarMockRecorder[T, R]) Two(arg0 interface{}) *gomock.Call {
+func (mr *MockBarMockRecorder[T, R]) Two(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Two", reflect.TypeOf((*MockBar[T, R])(nil).Two), arg0)
 }
@@ -361,7 +361,7 @@ func (m *MockUniverse[T]) Water(arg0 T) []T {
 }
 
 // Water indicates an expected call of Water.
-func (mr *MockUniverseMockRecorder[T]) Water(arg0 interface{}) *gomock.Call {
+func (mr *MockUniverseMockRecorder[T]) Water(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Water", reflect.TypeOf((*MockUniverse[T])(nil).Water), arg0)
 }
@@ -398,7 +398,7 @@ func (m *MockMilkyWay[R]) Water(arg0 R) []R {
 }
 
 // Water indicates an expected call of Water.
-func (mr *MockMilkyWayMockRecorder[R]) Water(arg0 interface{}) *gomock.Call {
+func (mr *MockMilkyWayMockRecorder[R]) Water(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Water", reflect.TypeOf((*MockMilkyWay[R])(nil).Water), arg0)
 }
@@ -435,7 +435,7 @@ func (m *MockSolarSystem[T]) Water(arg0 T) []T {
 }
 
 // Water indicates an expected call of Water.
-func (mr *MockSolarSystemMockRecorder[T]) Water(arg0 interface{}) *gomock.Call {
+func (mr *MockSolarSystemMockRecorder[T]) Water(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Water", reflect.TypeOf((*MockSolarSystem[T])(nil).Water), arg0)
 }
@@ -472,7 +472,7 @@ func (m *MockEarth[R]) Water(arg0 R) []R {
 }
 
 // Water indicates an expected call of Water.
-func (mr *MockEarthMockRecorder[R]) Water(arg0 interface{}) *gomock.Call {
+func (mr *MockEarthMockRecorder[R]) Water(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Water", reflect.TypeOf((*MockEarth[R])(nil).Water), arg0)
 }

--- a/mockgen/internal/tests/import_embedded_interface/ersatz/ersatz.go
+++ b/mockgen/internal/tests/import_embedded_interface/ersatz/ersatz.go
@@ -18,4 +18,4 @@ type Embedded interface {
 	Ersatz() Return
 }
 
-type Return interface{}
+type Return any

--- a/mockgen/internal/tests/import_embedded_interface/foo.go
+++ b/mockgen/internal/tests/import_embedded_interface/foo.go
@@ -3,4 +3,4 @@ package bugreport
 type Foo interface {
 	Bar() Baz
 }
-type Baz interface{}
+type Baz any

--- a/mockgen/internal/tests/import_embedded_interface/net_mock.go
+++ b/mockgen/internal/tests/import_embedded_interface/net_mock.go
@@ -62,7 +62,7 @@ func (m *MockNet) Write(arg0 []byte) (int, error) {
 }
 
 // Write indicates an expected call of Write.
-func (mr *MockNetMockRecorder) Write(arg0 interface{}) *gomock.Call {
+func (mr *MockNetMockRecorder) Write(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockNet)(nil).Write), arg0)
 }
@@ -74,7 +74,7 @@ func (m *MockNet) WriteHeader(statusCode int) {
 }
 
 // WriteHeader indicates an expected call of WriteHeader.
-func (mr *MockNetMockRecorder) WriteHeader(statusCode interface{}) *gomock.Call {
+func (mr *MockNetMockRecorder) WriteHeader(statusCode any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteHeader", reflect.TypeOf((*MockNet)(nil).WriteHeader), statusCode)
 }

--- a/mockgen/internal/tests/import_embedded_interface/other/ersatz/ersatz.go
+++ b/mockgen/internal/tests/import_embedded_interface/other/ersatz/ersatz.go
@@ -18,4 +18,4 @@ type Embedded interface {
 	OtherErsatz() Return
 }
 
-type Return interface{}
+type Return any

--- a/mockgen/internal/tests/import_source/definition/source_mock.go
+++ b/mockgen/internal/tests/import_source/definition/source_mock.go
@@ -44,7 +44,7 @@ func (m *MockS) F(arg0 X) {
 }
 
 // F indicates an expected call of F.
-func (mr *MockSMockRecorder) F(arg0 interface{}) *gomock.Call {
+func (mr *MockSMockRecorder) F(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "F", reflect.TypeOf((*MockS)(nil).F), arg0)
 }

--- a/mockgen/internal/tests/import_source/source_mock.go
+++ b/mockgen/internal/tests/import_source/source_mock.go
@@ -45,7 +45,7 @@ func (m *MockS) F(arg0 source.X) {
 }
 
 // F indicates an expected call of F.
-func (mr *MockSMockRecorder) F(arg0 interface{}) *gomock.Call {
+func (mr *MockSMockRecorder) F(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "F", reflect.TypeOf((*MockS)(nil).F), arg0)
 }

--- a/mockgen/internal/tests/missing_import/output/source_mock.go
+++ b/mockgen/internal/tests/missing_import/output/source_mock.go
@@ -45,7 +45,7 @@ func (m *MockBar) Baz(arg0 source.Foo) {
 }
 
 // Baz indicates an expected call of Baz.
-func (mr *MockBarMockRecorder) Baz(arg0 interface{}) *gomock.Call {
+func (mr *MockBarMockRecorder) Baz(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Baz", reflect.TypeOf((*MockBar)(nil).Baz), arg0)
 }

--- a/mockgen/internal/tests/mock_in_test_package/mock_test.go
+++ b/mockgen/internal/tests/mock_in_test_package/mock_test.go
@@ -45,7 +45,7 @@ func (m *MockFinder) Add(u users.User) {
 }
 
 // Add indicates an expected call of Add.
-func (mr *MockFinderMockRecorder) Add(u interface{}) *gomock.Call {
+func (mr *MockFinderMockRecorder) Add(u any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockFinder)(nil).Add), u)
 }
@@ -59,7 +59,7 @@ func (m *MockFinder) FindUser(name string) users.User {
 }
 
 // FindUser indicates an expected call of FindUser.
-func (mr *MockFinderMockRecorder) FindUser(name interface{}) *gomock.Call {
+func (mr *MockFinderMockRecorder) FindUser(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUser", reflect.TypeOf((*MockFinder)(nil).FindUser), name)
 }

--- a/mockgen/internal/tests/overlapping_methods/mock.go
+++ b/mockgen/internal/tests/overlapping_methods/mock.go
@@ -61,7 +61,7 @@ func (m *MockReadWriteCloser) Read(arg0 []byte) (int, error) {
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockReadWriteCloserMockRecorder) Read(arg0 interface{}) *gomock.Call {
+func (mr *MockReadWriteCloserMockRecorder) Read(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockReadWriteCloser)(nil).Read), arg0)
 }
@@ -76,7 +76,7 @@ func (m *MockReadWriteCloser) Write(arg0 []byte) (int, error) {
 }
 
 // Write indicates an expected call of Write.
-func (mr *MockReadWriteCloserMockRecorder) Write(arg0 interface{}) *gomock.Call {
+func (mr *MockReadWriteCloserMockRecorder) Write(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockReadWriteCloser)(nil).Write), arg0)
 }

--- a/mockgen/internal/tests/parenthesized_parameter_type/mock.go
+++ b/mockgen/internal/tests/parenthesized_parameter_type/mock.go
@@ -39,7 +39,7 @@ func (m *MockExample) ParenthesizedParameterType(param *int) {
 }
 
 // ParenthesizedParameterType indicates an expected call of ParenthesizedParameterType.
-func (mr *MockExampleMockRecorder) ParenthesizedParameterType(param interface{}) *gomock.Call {
+func (mr *MockExampleMockRecorder) ParenthesizedParameterType(param any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParenthesizedParameterType", reflect.TypeOf((*MockExample)(nil).ParenthesizedParameterType), param)
 }

--- a/mockgen/internal/tests/test_package/mock_test.go
+++ b/mockgen/internal/tests/test_package/mock_test.go
@@ -44,7 +44,7 @@ func (m *MockFinder) Add(u User) {
 }
 
 // Add indicates an expected call of Add.
-func (mr *MockFinderMockRecorder) Add(u interface{}) *gomock.Call {
+func (mr *MockFinderMockRecorder) Add(u any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockFinder)(nil).Add), u)
 }
@@ -58,7 +58,7 @@ func (m *MockFinder) FindUser(name string) User {
 }
 
 // FindUser indicates an expected call of FindUser.
-func (mr *MockFinderMockRecorder) FindUser(name interface{}) *gomock.Call {
+func (mr *MockFinderMockRecorder) FindUser(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUser", reflect.TypeOf((*MockFinder)(nil).FindUser), name)
 }

--- a/mockgen/internal/tests/typed/faux/faux.go
+++ b/mockgen/internal/tests/typed/faux/faux.go
@@ -6,6 +6,6 @@ type Foreign interface {
 	error
 }
 
-type Embedded interface{}
+type Embedded any
 
-type Return interface{}
+type Return any

--- a/mockgen/internal/tests/typed/generics.go
+++ b/mockgen/internal/tests/typed/generics.go
@@ -31,7 +31,7 @@ type Foo[T any, R any] struct{}
 
 type Baz[T any] struct{}
 
-type Iface[T any] interface{}
+type Iface[T any] any
 
 type StructType struct{}
 

--- a/mockgen/internal/tests/typed/other/other.go
+++ b/mockgen/internal/tests/typed/other/other.go
@@ -8,4 +8,4 @@ type Three struct{}
 
 type Four struct{}
 
-type Five interface{}
+type Five any

--- a/mockgen/internal/tests/typed/source/mock_external_test.go
+++ b/mockgen/internal/tests/typed/source/mock_external_test.go
@@ -45,7 +45,7 @@ func (m *MockExternalConstraint[I, F]) Eight(arg0 F) other.Two[I, F] {
 }
 
 // Eight indicates an expected call of Eight.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Eight(arg0 interface{}) *ExternalConstraintEightCall[I, F] {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Eight(arg0 any) *ExternalConstraintEightCall[I, F] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eight", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Eight), arg0)
 	return &ExternalConstraintEightCall[I, F]{Call: call}
@@ -83,7 +83,7 @@ func (m *MockExternalConstraint[I, F]) Five(arg0 I) typed.Baz[F] {
 }
 
 // Five indicates an expected call of Five.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Five(arg0 interface{}) *ExternalConstraintFiveCall[I, F] {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Five(arg0 any) *ExternalConstraintFiveCall[I, F] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Five", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Five), arg0)
 	return &ExternalConstraintFiveCall[I, F]{Call: call}
@@ -121,7 +121,7 @@ func (m *MockExternalConstraint[I, F]) Four(arg0 I) typed.Foo[I, F] {
 }
 
 // Four indicates an expected call of Four.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Four(arg0 interface{}) *ExternalConstraintFourCall[I, F] {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Four(arg0 any) *ExternalConstraintFourCall[I, F] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Four", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Four), arg0)
 	return &ExternalConstraintFourCall[I, F]{Call: call}
@@ -157,7 +157,7 @@ func (m *MockExternalConstraint[I, F]) Nine(arg0 typed.Iface[I]) {
 }
 
 // Nine indicates an expected call of Nine.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Nine(arg0 interface{}) *ExternalConstraintNineCall[I, F] {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Nine(arg0 any) *ExternalConstraintNineCall[I, F] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nine", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Nine), arg0)
 	return &ExternalConstraintNineCall[I, F]{Call: call}
@@ -195,7 +195,7 @@ func (m *MockExternalConstraint[I, F]) One(arg0 string) string {
 }
 
 // One indicates an expected call of One.
-func (mr *MockExternalConstraintMockRecorder[I, F]) One(arg0 interface{}) *ExternalConstraintOneCall[I, F] {
+func (mr *MockExternalConstraintMockRecorder[I, F]) One(arg0 any) *ExternalConstraintOneCall[I, F] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "One", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).One), arg0)
 	return &ExternalConstraintOneCall[I, F]{Call: call}
@@ -233,7 +233,7 @@ func (m *MockExternalConstraint[I, F]) Seven(arg0 I) other.One[I] {
 }
 
 // Seven indicates an expected call of Seven.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Seven(arg0 interface{}) *ExternalConstraintSevenCall[I, F] {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Seven(arg0 any) *ExternalConstraintSevenCall[I, F] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seven", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Seven), arg0)
 	return &ExternalConstraintSevenCall[I, F]{Call: call}
@@ -271,7 +271,7 @@ func (m *MockExternalConstraint[I, F]) Six(arg0 I) *typed.Baz[F] {
 }
 
 // Six indicates an expected call of Six.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Six(arg0 interface{}) *ExternalConstraintSixCall[I, F] {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Six(arg0 any) *ExternalConstraintSixCall[I, F] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Six", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Six), arg0)
 	return &ExternalConstraintSixCall[I, F]{Call: call}
@@ -307,7 +307,7 @@ func (m *MockExternalConstraint[I, F]) Ten(arg0 *I) {
 }
 
 // Ten indicates an expected call of Ten.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Ten(arg0 interface{}) *ExternalConstraintTenCall[I, F] {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Ten(arg0 any) *ExternalConstraintTenCall[I, F] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ten", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Ten), arg0)
 	return &ExternalConstraintTenCall[I, F]{Call: call}
@@ -345,7 +345,7 @@ func (m *MockExternalConstraint[I, F]) Three(arg0 I) F {
 }
 
 // Three indicates an expected call of Three.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Three(arg0 interface{}) *ExternalConstraintThreeCall[I, F] {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Three(arg0 any) *ExternalConstraintThreeCall[I, F] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Three", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Three), arg0)
 	return &ExternalConstraintThreeCall[I, F]{Call: call}
@@ -383,7 +383,7 @@ func (m *MockExternalConstraint[I, F]) Two(arg0 I) string {
 }
 
 // Two indicates an expected call of Two.
-func (mr *MockExternalConstraintMockRecorder[I, F]) Two(arg0 interface{}) *ExternalConstraintTwoCall[I, F] {
+func (mr *MockExternalConstraintMockRecorder[I, F]) Two(arg0 any) *ExternalConstraintTwoCall[I, F] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Two", reflect.TypeOf((*MockExternalConstraint[I, F])(nil).Two), arg0)
 	return &ExternalConstraintTwoCall[I, F]{Call: call}

--- a/mockgen/internal/tests/typed/source/mock_generics_test.go
+++ b/mockgen/internal/tests/typed/source/mock_generics_test.go
@@ -44,7 +44,7 @@ func (m *MockBar[T, R]) Eight(arg0 T) other.Two[T, R] {
 }
 
 // Eight indicates an expected call of Eight.
-func (mr *MockBarMockRecorder[T, R]) Eight(arg0 interface{}) *BarEightCall[T, R] {
+func (mr *MockBarMockRecorder[T, R]) Eight(arg0 any) *BarEightCall[T, R] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eight", reflect.TypeOf((*MockBar[T, R])(nil).Eight), arg0)
 	return &BarEightCall[T, R]{Call: call}
@@ -199,7 +199,7 @@ func (m *MockBar[T, R]) Five(arg0 T) typed.Baz[T] {
 }
 
 // Five indicates an expected call of Five.
-func (mr *MockBarMockRecorder[T, R]) Five(arg0 interface{}) *BarFiveCall[T, R] {
+func (mr *MockBarMockRecorder[T, R]) Five(arg0 any) *BarFiveCall[T, R] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Five", reflect.TypeOf((*MockBar[T, R])(nil).Five), arg0)
 	return &BarFiveCall[T, R]{Call: call}
@@ -237,7 +237,7 @@ func (m *MockBar[T, R]) Four(arg0 T) typed.Foo[T, R] {
 }
 
 // Four indicates an expected call of Four.
-func (mr *MockBarMockRecorder[T, R]) Four(arg0 interface{}) *BarFourCall[T, R] {
+func (mr *MockBarMockRecorder[T, R]) Four(arg0 any) *BarFourCall[T, R] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Four", reflect.TypeOf((*MockBar[T, R])(nil).Four), arg0)
 	return &BarFourCall[T, R]{Call: call}
@@ -312,7 +312,7 @@ func (m *MockBar[T, R]) Nine(arg0 typed.Iface[T]) {
 }
 
 // Nine indicates an expected call of Nine.
-func (mr *MockBarMockRecorder[T, R]) Nine(arg0 interface{}) *BarNineCall[T, R] {
+func (mr *MockBarMockRecorder[T, R]) Nine(arg0 any) *BarNineCall[T, R] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nine", reflect.TypeOf((*MockBar[T, R])(nil).Nine), arg0)
 	return &BarNineCall[T, R]{Call: call}
@@ -388,7 +388,7 @@ func (m *MockBar[T, R]) One(arg0 string) string {
 }
 
 // One indicates an expected call of One.
-func (mr *MockBarMockRecorder[T, R]) One(arg0 interface{}) *BarOneCall[T, R] {
+func (mr *MockBarMockRecorder[T, R]) One(arg0 any) *BarOneCall[T, R] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "One", reflect.TypeOf((*MockBar[T, R])(nil).One), arg0)
 	return &BarOneCall[T, R]{Call: call}
@@ -426,7 +426,7 @@ func (m *MockBar[T, R]) Seven(arg0 T) other.One[T] {
 }
 
 // Seven indicates an expected call of Seven.
-func (mr *MockBarMockRecorder[T, R]) Seven(arg0 interface{}) *BarSevenCall[T, R] {
+func (mr *MockBarMockRecorder[T, R]) Seven(arg0 any) *BarSevenCall[T, R] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seven", reflect.TypeOf((*MockBar[T, R])(nil).Seven), arg0)
 	return &BarSevenCall[T, R]{Call: call}
@@ -503,7 +503,7 @@ func (m *MockBar[T, R]) Six(arg0 T) *typed.Baz[T] {
 }
 
 // Six indicates an expected call of Six.
-func (mr *MockBarMockRecorder[T, R]) Six(arg0 interface{}) *BarSixCall[T, R] {
+func (mr *MockBarMockRecorder[T, R]) Six(arg0 any) *BarSixCall[T, R] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Six", reflect.TypeOf((*MockBar[T, R])(nil).Six), arg0)
 	return &BarSixCall[T, R]{Call: call}
@@ -578,7 +578,7 @@ func (m *MockBar[T, R]) Ten(arg0 *T) {
 }
 
 // Ten indicates an expected call of Ten.
-func (mr *MockBarMockRecorder[T, R]) Ten(arg0 interface{}) *BarTenCall[T, R] {
+func (mr *MockBarMockRecorder[T, R]) Ten(arg0 any) *BarTenCall[T, R] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ten", reflect.TypeOf((*MockBar[T, R])(nil).Ten), arg0)
 	return &BarTenCall[T, R]{Call: call}
@@ -655,7 +655,7 @@ func (m *MockBar[T, R]) Three(arg0 T) R {
 }
 
 // Three indicates an expected call of Three.
-func (mr *MockBarMockRecorder[T, R]) Three(arg0 interface{}) *BarThreeCall[T, R] {
+func (mr *MockBarMockRecorder[T, R]) Three(arg0 any) *BarThreeCall[T, R] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Three", reflect.TypeOf((*MockBar[T, R])(nil).Three), arg0)
 	return &BarThreeCall[T, R]{Call: call}
@@ -732,7 +732,7 @@ func (m *MockBar[T, R]) Two(arg0 T) string {
 }
 
 // Two indicates an expected call of Two.
-func (mr *MockBarMockRecorder[T, R]) Two(arg0 interface{}) *BarTwoCall[T, R] {
+func (mr *MockBarMockRecorder[T, R]) Two(arg0 any) *BarTwoCall[T, R] {
 	mr.mock.ctrl.T.Helper()
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Two", reflect.TypeOf((*MockBar[T, R])(nil).Two), arg0)
 	return &BarTwoCall[T, R]{Call: call}

--- a/mockgen/internal/tests/unexported_method/bugreport_mock.go
+++ b/mockgen/internal/tests/unexported_method/bugreport_mock.go
@@ -46,7 +46,7 @@ func (m *MockExample) someMethod(arg0 string) string {
 }
 
 // someMethod indicates an expected call of someMethod.
-func (mr *MockExampleMockRecorder) someMethod(arg0 interface{}) *gomock.Call {
+func (mr *MockExampleMockRecorder) someMethod(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "someMethod", reflect.TypeOf((*MockExample)(nil).someMethod), arg0)
 }

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -231,7 +231,7 @@ type generator struct {
 	packageMap map[string]string // map from import path to package name
 }
 
-func (g *generator) p(format string, args ...interface{}) {
+func (g *generator) p(format string, args ...any) {
 	fmt.Fprintf(&g.buf, g.indent+format+"\n", args...)
 }
 
@@ -520,11 +520,11 @@ func (g *generator) GenerateMockMethod(mockType string, m *model.Method, pkgOver
 			callArgs = ", " + strings.Join(argNames, ", ")
 		}
 	} else {
-		// Non-trivial. The generated code must build a []interface{},
+		// Non-trivial. The generated code must build a []any,
 		// but the variadic argument may be any type.
 		idVarArgs := ia.allocateIdentifier("varargs")
 		idVArg := ia.allocateIdentifier("a")
-		g.p("%s := []interface{}{%s}", idVarArgs, strings.Join(argNames[:len(argNames)-1], ", "))
+		g.p("%s := []any{%s}", idVarArgs, strings.Join(argNames[:len(argNames)-1], ", "))
 		g.p("for _, %s := range %s {", idVArg, argNames[len(argNames)-1])
 		g.in()
 		g.p("%s = append(%s, %s)", idVarArgs, idVarArgs, idVArg)
@@ -564,14 +564,14 @@ func (g *generator) GenerateMockRecorderMethod(intf *model.Interface, mockType s
 		argString = strings.Join(argNames[:len(argNames)-1], ", ")
 	}
 	if argString != "" {
-		argString += " interface{}"
+		argString += " any"
 	}
 
 	if m.Variadic != nil {
 		if argString != "" {
 			argString += ", "
 		}
-		argString += fmt.Sprintf("%s ...interface{}", argNames[len(argNames)-1])
+		argString += fmt.Sprintf("%s ...any", argNames[len(argNames)-1])
 	}
 
 	ia := newIdentifierAllocator(argNames)
@@ -599,7 +599,7 @@ func (g *generator) GenerateMockRecorderMethod(intf *model.Interface, mockType s
 		} else {
 			// Hard: create a temporary slice.
 			idVarArgs := ia.allocateIdentifier("varargs")
-			g.p("%s := append([]interface{}{%s}, %s...)",
+			g.p("%s := append([]any{%s}, %s...)",
 				idVarArgs,
 				strings.Join(argNames[:len(argNames)-1], ", "),
 				argNames[len(argNames)-1])

--- a/mockgen/model/model.go
+++ b/mockgen/model/model.go
@@ -467,7 +467,7 @@ func typeFromType(t reflect.Type) (Type, error) {
 	case reflect.Interface:
 		// Two special interfaces.
 		if t.NumMethod() == 0 {
-			return PredeclaredType("interface{}"), nil
+			return PredeclaredType("any"), nil
 		}
 		if t == errorType {
 			return PredeclaredType("error"), nil

--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -171,10 +171,10 @@ type fileParser struct {
 	srcDir             string
 }
 
-func (p *fileParser) errorf(pos token.Pos, format string, args ...interface{}) error {
+func (p *fileParser) errorf(pos token.Pos, format string, args ...any) error {
 	ps := p.fileSet.Position(pos)
 	format = "%s:%d:%d: " + format
-	args = append([]interface{}{ps.Filename, ps.Line, ps.Column}, args...)
+	args = append([]any{ps.Filename, ps.Line, ps.Column}, args...)
 	return fmt.Errorf(format, args...)
 }
 
@@ -581,7 +581,7 @@ func (p *fileParser) parseType(pkg string, typ ast.Expr, tps map[string]model.Ty
 		if v.Methods != nil && len(v.Methods.List) > 0 {
 			return nil, p.errorf(v.Pos(), "can't handle non-empty unnamed interface types")
 		}
-		return model.PredeclaredType("interface{}"), nil
+		return model.PredeclaredType("any"), nil
 	case *ast.MapType:
 		key, err := p.parseType(pkg, v.Key, tps)
 		if err != nil {

--- a/sample/concurrent/mock/concurrent_mock.go
+++ b/sample/concurrent/mock/concurrent_mock.go
@@ -46,7 +46,7 @@ func (m *MockMath) Sum(arg0, arg1 int) int {
 }
 
 // Sum indicates an expected call of Sum.
-func (mr *MockMathMockRecorder) Sum(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMathMockRecorder) Sum(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sum", reflect.TypeOf((*MockMath)(nil).Sum), arg0, arg1)
 }

--- a/sample/mock_user_test.go
+++ b/sample/mock_user_test.go
@@ -55,7 +55,7 @@ func (m *MockIndex) Anon(arg0 string) {
 }
 
 // Anon indicates an expected call of Anon.
-func (mr *MockIndexMockRecorder) Anon(arg0 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Anon(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Anon", reflect.TypeOf((*MockIndex)(nil).Anon), arg0)
 }
@@ -67,7 +67,7 @@ func (m *MockIndex) Chan(arg0 chan int, arg1 chan<- hash.Hash) {
 }
 
 // Chan indicates an expected call of Chan.
-func (mr *MockIndexMockRecorder) Chan(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Chan(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chan", reflect.TypeOf((*MockIndex)(nil).Chan), arg0, arg1)
 }
@@ -87,9 +87,9 @@ func (mr *MockIndexMockRecorder) ConcreteRet() *gomock.Call {
 }
 
 // Ellip mocks base method.
-func (m *MockIndex) Ellip(arg0 string, arg1 ...interface{}) {
+func (m *MockIndex) Ellip(arg0 string, arg1 ...any) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0}
+	varargs := []any{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
@@ -97,16 +97,16 @@ func (m *MockIndex) Ellip(arg0 string, arg1 ...interface{}) {
 }
 
 // Ellip indicates an expected call of Ellip.
-func (mr *MockIndexMockRecorder) Ellip(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Ellip(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0}, arg1...)
+	varargs := append([]any{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ellip", reflect.TypeOf((*MockIndex)(nil).Ellip), varargs...)
 }
 
 // EllipOnly mocks base method.
 func (m *MockIndex) EllipOnly(arg0 ...string) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{}
+	varargs := []any{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
 	}
@@ -114,7 +114,7 @@ func (m *MockIndex) EllipOnly(arg0 ...string) {
 }
 
 // EllipOnly indicates an expected call of EllipOnly.
-func (mr *MockIndexMockRecorder) EllipOnly(arg0 ...interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) EllipOnly(arg0 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EllipOnly", reflect.TypeOf((*MockIndex)(nil).EllipOnly), arg0...)
 }
@@ -126,7 +126,7 @@ func (m *MockIndex) ForeignFour(arg0 imp_four.Imp4) {
 }
 
 // ForeignFour indicates an expected call of ForeignFour.
-func (mr *MockIndexMockRecorder) ForeignFour(arg0 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) ForeignFour(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForeignFour", reflect.TypeOf((*MockIndex)(nil).ForeignFour), arg0)
 }
@@ -138,7 +138,7 @@ func (m *MockIndex) ForeignOne(arg0 imp1.Imp1) {
 }
 
 // ForeignOne indicates an expected call of ForeignOne.
-func (mr *MockIndexMockRecorder) ForeignOne(arg0 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) ForeignOne(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForeignOne", reflect.TypeOf((*MockIndex)(nil).ForeignOne), arg0)
 }
@@ -150,7 +150,7 @@ func (m *MockIndex) ForeignThree(arg0 imp3.Imp3) {
 }
 
 // ForeignThree indicates an expected call of ForeignThree.
-func (mr *MockIndexMockRecorder) ForeignThree(arg0 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) ForeignThree(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForeignThree", reflect.TypeOf((*MockIndex)(nil).ForeignThree), arg0)
 }
@@ -162,7 +162,7 @@ func (m *MockIndex) ForeignTwo(arg0 imp2.Imp2) {
 }
 
 // ForeignTwo indicates an expected call of ForeignTwo.
-func (mr *MockIndexMockRecorder) ForeignTwo(arg0 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) ForeignTwo(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForeignTwo", reflect.TypeOf((*MockIndex)(nil).ForeignTwo), arg0)
 }
@@ -174,36 +174,36 @@ func (m *MockIndex) Func(arg0 func(http.Request) (int, bool)) {
 }
 
 // Func indicates an expected call of Func.
-func (mr *MockIndexMockRecorder) Func(arg0 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Func(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Func", reflect.TypeOf((*MockIndex)(nil).Func), arg0)
 }
 
 // Get mocks base method.
-func (m *MockIndex) Get(arg0 string) interface{} {
+func (m *MockIndex) Get(arg0 string) any {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(any)
 	return ret0
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockIndexMockRecorder) Get(arg0 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Get(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockIndex)(nil).Get), arg0)
 }
 
 // GetTwo mocks base method.
-func (m *MockIndex) GetTwo(arg0, arg1 string) (interface{}, interface{}) {
+func (m *MockIndex) GetTwo(arg0, arg1 string) (any, any) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTwo", arg0, arg1)
-	ret0, _ := ret[0].(interface{})
-	ret1, _ := ret[1].(interface{})
+	ret0, _ := ret[0].(any)
+	ret1, _ := ret[1].(any)
 	return ret0, ret1
 }
 
 // GetTwo indicates an expected call of GetTwo.
-func (mr *MockIndexMockRecorder) GetTwo(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) GetTwo(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTwo", reflect.TypeOf((*MockIndex)(nil).GetTwo), arg0, arg1)
 }
@@ -215,7 +215,7 @@ func (m *MockIndex) Map(arg0 map[int]hash.Hash) {
 }
 
 // Map indicates an expected call of Map.
-func (mr *MockIndexMockRecorder) Map(arg0 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Map(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Map", reflect.TypeOf((*MockIndex)(nil).Map), arg0)
 }
@@ -255,19 +255,19 @@ func (m *MockIndex) Ptr(arg0 *int) {
 }
 
 // Ptr indicates an expected call of Ptr.
-func (mr *MockIndexMockRecorder) Ptr(arg0 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Ptr(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ptr", reflect.TypeOf((*MockIndex)(nil).Ptr), arg0)
 }
 
 // Put mocks base method.
-func (m *MockIndex) Put(arg0 string, arg1 interface{}) {
+func (m *MockIndex) Put(arg0 string, arg1 any) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Put", arg0, arg1)
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockIndexMockRecorder) Put(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Put(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockIndex)(nil).Put), arg0, arg1)
 }
@@ -281,7 +281,7 @@ func (m *MockIndex) Slice(arg0 []int, arg1 []byte) [3]int {
 }
 
 // Slice indicates an expected call of Slice.
-func (mr *MockIndexMockRecorder) Slice(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Slice(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Slice", reflect.TypeOf((*MockIndex)(nil).Slice), arg0, arg1)
 }
@@ -293,7 +293,7 @@ func (m *MockIndex) Struct(arg0 struct{}) {
 }
 
 // Struct indicates an expected call of Struct.
-func (mr *MockIndexMockRecorder) Struct(arg0 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Struct(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Struct", reflect.TypeOf((*MockIndex)(nil).Struct), arg0)
 }
@@ -305,7 +305,7 @@ func (m *MockIndex) StructChan(arg0 chan struct{}) {
 }
 
 // StructChan indicates an expected call of StructChan.
-func (mr *MockIndexMockRecorder) StructChan(arg0 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) StructChan(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StructChan", reflect.TypeOf((*MockIndex)(nil).StructChan), arg0)
 }
@@ -317,7 +317,7 @@ func (m *MockIndex) Summary(arg0 *bytes.Buffer, arg1 io.Writer) {
 }
 
 // Summary indicates an expected call of Summary.
-func (mr *MockIndexMockRecorder) Summary(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Summary(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Summary", reflect.TypeOf((*MockIndex)(nil).Summary), arg0, arg1)
 }
@@ -329,7 +329,7 @@ func (m *MockIndex) Templates(arg0 template.CSS, arg1 template0.FuncMap) {
 }
 
 // Templates indicates an expected call of Templates.
-func (mr *MockIndexMockRecorder) Templates(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockIndexMockRecorder) Templates(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Templates", reflect.TypeOf((*MockIndex)(nil).Templates), arg0, arg1)
 }
@@ -390,7 +390,7 @@ func (m *MockEmbed) ImplicitPackage(arg0 string, arg1 imp1.ImpT, arg2 []imp1.Imp
 }
 
 // ImplicitPackage indicates an expected call of ImplicitPackage.
-func (mr *MockEmbedMockRecorder) ImplicitPackage(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockEmbedMockRecorder) ImplicitPackage(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImplicitPackage", reflect.TypeOf((*MockEmbed)(nil).ImplicitPackage), arg0, arg1, arg2, arg3, arg4)
 }

--- a/sample/user.go
+++ b/sample/user.go
@@ -35,9 +35,9 @@ import (
 // This would normally be in its own file or package,
 // separate from the user of it (e.g. io.Reader).
 type Index interface {
-	Get(key string) interface{}
-	GetTwo(key1, key2 string) (v1, v2 interface{})
-	Put(key string, value interface{})
+	Get(key string) any
+	GetTwo(key1, key2 string) (v1, v2 any)
+	Put(key string, value any)
 
 	// Check that imports are handled correctly.
 	Summary(buf *btz.Buffer, w io.Writer)
@@ -59,7 +59,7 @@ type Index interface {
 	ConcreteRet() chan<- bool
 
 	// Methods with an ellipsis argument.
-	Ellip(fmt string, args ...interface{})
+	Ellip(fmt string, args ...any)
 	EllipOnly(...string)
 
 	// A method with a pointer argument that we will set.
@@ -98,7 +98,7 @@ var _ net.Addr
 
 // A function that we will test that uses the above interface.
 // It takes a list of keys and values, and puts them in the index.
-func Remember(index Index, keys []string, values []interface{}) {
+func Remember(index Index, keys []string, values []any) {
 	for i, k := range keys {
 		index.Put(k, values[i])
 	}

--- a/sample/user_test.go
+++ b/sample/user_test.go
@@ -28,11 +28,11 @@ func TestRemember(t *testing.T) {
 
 	// Should be able to place expectations on variadic methods.
 	mockIndex.EXPECT().Ellip("%d", 0, 1, 1, 2, 3) // direct args
-	tri := []interface{}{1, 3, 6, 10, 15}
+	tri := []any{1, 3, 6, 10, 15}
 	mockIndex.EXPECT().Ellip("%d", tri...) // args from slice
 	mockIndex.EXPECT().EllipOnly(gomock.Eq("arg"))
 
-	user.Remember(mockIndex, []string{"a", "b"}, []interface{}{1, 2})
+	user.Remember(mockIndex, []string{"a", "b"}, []any{1, 2})
 	// Check the ConcreteRet calls.
 	if c := mockIndex.ConcreteRet(); c != boolc {
 		t.Errorf("ConcreteRet: got %v, want %v", c, boolc)
@@ -43,23 +43,23 @@ func TestRemember(t *testing.T) {
 
 	// Try one with an action.
 	calledString := ""
-	mockIndex.EXPECT().Put(gomock.Any(), gomock.Any()).Do(func(key string, _ interface{}) {
+	mockIndex.EXPECT().Put(gomock.Any(), gomock.Any()).Do(func(key string, _ any) {
 		calledString = key
 	})
 	mockIndex.EXPECT().NillableRet()
-	user.Remember(mockIndex, []string{"blah"}, []interface{}{7})
+	user.Remember(mockIndex, []string{"blah"}, []any{7})
 	if calledString != "blah" {
 		t.Fatalf(`Uh oh. %q != "blah"`, calledString)
 	}
 
 	// Use Do with a nil arg.
-	mockIndex.EXPECT().Put("nil-key", gomock.Any()).Do(func(key string, value interface{}) {
+	mockIndex.EXPECT().Put("nil-key", gomock.Any()).Do(func(key string, value any) {
 		if value != nil {
 			t.Errorf("Put did not pass through nil; got %v", value)
 		}
 	})
 	mockIndex.EXPECT().NillableRet()
-	user.Remember(mockIndex, []string{"nil-key"}, []interface{}{nil})
+	user.Remember(mockIndex, []string{"nil-key"}, []any{nil})
 }
 
 func TestVariadicFunction(t *testing.T) {
@@ -155,7 +155,7 @@ func TestExpectTrueNil(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockIndex := NewMockIndex(ctrl)
-	mockIndex.EXPECT().Ptr(nil) // this nil is a nil interface{}
+	mockIndex.EXPECT().Ptr(nil) // this nil is a nil any
 	mockIndex.Ptr(nil)          // this nil is a nil *int
 }
 


### PR DESCRIPTION
This PR replaces `interface{}` with `any` by running the command:
```sh
gofmt -w -r 'interface{} -> any' .
```