### PR TITLE
feat: add Cond matcher 

### DIFF
--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -97,15 +97,15 @@ func (anyMatcher) String() string {
 	return "is anything"
 }
 
-type fnMatcher struct {
+type condMatcher struct {
 	fn func(x any) bool
 }
 
-func (f fnMatcher) Matches(x any) bool {
-	return f.fn(x)
+func (c condMatcher) Matches(x any) bool {
+	return c.fn(x)
 }
 
-func (fnMatcher) String() string {
+func (condMatcher) String() string {
 	return "adheres to a custom condition"
 }
 
@@ -292,14 +292,14 @@ func All(ms ...Matcher) Matcher { return allMatcher{ms} }
 // Any returns a matcher that always matches.
 func Any() Matcher { return anyMatcher{} }
 
-// Fn returns a specialized matchers customizable for complex matching behaviour.
+// Cond returns a specialized matchers customizable for complex matching behaviour.
 // This is particularly useful in case you want to match over a field of a custom struct, or dynamic logic.
 //
 // Example usage:
 //
-//	Fn(func(x any){return x.(int) == 1}).Matches(1) // returns true
-//	Fn(func(x any){return x.(int) == 2}).Matches(1) // returns false
-func Fn(fn func(x any) bool) Matcher { return fnMatcher{fn} }
+//	Cond(func(x any){return x.(int) == 1}).Matches(1) // returns true
+//	Cond(func(x any){return x.(int) == 2}).Matches(1) // returns false
+func Cond(fn func(x any) bool) Matcher { return condMatcher{fn} }
 
 // Eq returns a matcher that matches on equality.
 //

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -106,7 +106,7 @@ func (f fnMatcher) Matches(x any) bool {
 }
 
 func (fnMatcher) String() string {
-	return "a customizable behaviour"
+	return "adheres to a custom condition"
 }
 
 type eqMatcher struct {

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -97,6 +97,18 @@ func (anyMatcher) String() string {
 	return "is anything"
 }
 
+type fnMatcher struct {
+	fn func(x any) bool
+}
+
+func (f fnMatcher) Matches(x any) bool {
+	return f.fn(x)
+}
+
+func (fnMatcher) String() string {
+	return "a customizable behaviour"
+}
+
 type eqMatcher struct {
 	x any
 }
@@ -279,6 +291,15 @@ func All(ms ...Matcher) Matcher { return allMatcher{ms} }
 
 // Any returns a matcher that always matches.
 func Any() Matcher { return anyMatcher{} }
+
+// Fn returns a specialized matchers customizable for complex matching behaviour.
+// This is particularly useful in case you want to match over a field of a custom struct, or dynamic logic.
+//
+// Example usage:
+//
+//	Fn(func(x any){return x.(int) == 1}).Matches(1) // returns true
+//	Fn(func(x any){return x.(int) == 2}).Matches(1) // returns false
+func Fn(fn func(x any) bool) Matcher { return fnMatcher{fn} }
 
 // Eq returns a matcher that matches on equality.
 //

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -292,7 +292,8 @@ func All(ms ...Matcher) Matcher { return allMatcher{ms} }
 // Any returns a matcher that always matches.
 func Any() Matcher { return anyMatcher{} }
 
-// Cond returns a specialized matchers customizable for complex matching behaviour.
+// Cond returns a matcher that matches when the given function returns true
+// after passing it the parameter to the mock function.
 // This is particularly useful in case you want to match over a field of a custom struct, or dynamic logic.
 //
 // Example usage:

--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -53,7 +53,7 @@ func TestMatchers(t *testing.T) {
 			[]e{[]string{"a", "b"}, A{"a", "b"}},
 			[]e{[]string{"a"}, A{"b"}},
 		},
-		{"test Fn", gomock.Fn(func(x any) bool { return x.(B).Name == "Dam" }), []e{B{Name: "Dam"}}, []e{B{Name: "Dave"}}},
+		{"test Cond", gomock.Cond(func(x any) bool { return x.(B).Name == "Dam" }), []e{B{Name: "Dam"}}, []e{B{Name: "Dave"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -27,6 +27,9 @@ import (
 )
 
 type A []string
+type B struct {
+	Name string
+}
 
 func TestMatchers(t *testing.T) {
 	type e any
@@ -50,6 +53,7 @@ func TestMatchers(t *testing.T) {
 			[]e{[]string{"a", "b"}, A{"a", "b"}},
 			[]e{[]string{"a"}, A{"b"}},
 		},
+		{"test Fn", gomock.Fn(func(x any) bool { return x.(B).Name == "Dam" }), []e{B{Name: "Dam"}}, []e{B{Name: "Dave"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/sample/imp4/imp4.go
+++ b/sample/imp4/imp4.go
@@ -1,3 +1,5 @@
 package imp_four
 
-type Imp4 struct{}
+type Imp4 struct {
+	Field string
+}

--- a/sample/user_test.go
+++ b/sample/user_test.go
@@ -195,12 +195,12 @@ func TestDoAndReturnSignature(t *testing.T) {
 	})
 }
 
-func TestExpectFnForeignFour(t *testing.T) {
+func TestExpectCondForeignFour(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockIndex := NewMockIndex(ctrl)
-	mockIndex.EXPECT().ForeignFour(gomock.Fn(func(x any) bool {
+	mockIndex.EXPECT().ForeignFour(gomock.Cond(func(x any) bool {
 		four, ok := x.(imp_four.Imp4)
 		if !ok {
 			return false

--- a/sample/user_test.go
+++ b/sample/user_test.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/mock/gomock"
 	user "go.uber.org/mock/sample"
 	"go.uber.org/mock/sample/imp1"
+	imp_four "go.uber.org/mock/sample/imp4"
 )
 
 func TestRemember(t *testing.T) {
@@ -192,4 +193,20 @@ func TestDoAndReturnSignature(t *testing.T) {
 
 		mockIndex.Slice([]int{0}, []byte("meow"))
 	})
+}
+
+func TestExpectFnForeignFour(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIndex := NewMockIndex(ctrl)
+	mockIndex.EXPECT().ForeignFour(gomock.Fn(func(x any) bool {
+		four, ok := x.(imp_four.Imp4)
+		if !ok {
+			return false
+		}
+		return four.Field == "Cool"
+	}))
+
+	mockIndex.ForeignFour(imp_four.Imp4{Field: "Cool"})
 }


### PR DESCRIPTION
`Cond` is a matcher allowing to rely on custom logic for complex matching scenarios.

It happened quite a few times that I had to leverage on the `DoAndReturn` to perform complex matching use cases, passing `gomock.Any()` as a matcher.

This would have allowed me to reduce a lot of complexity.
