### PR TITLE
Proto specific comparison

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.uber.org/mock
 go 1.20
 
 require (
+	github.com/golang/protobuf v1.5.0
 	golang.org/x/mod v0.11.0
 	golang.org/x/tools v0.2.0
 )
@@ -10,4 +11,5 @@ require (
 require (
 	github.com/yuin/goldmark v1.4.13 // indirect
 	golang.org/x/sys v0.1.0 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/mod v0.11.0 h1:bUO06HqtnRcc/7l71XBe4WcqTZ+3AH1J59zWDDwLKgU=
@@ -6,3 +10,8 @@ golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/tools v0.2.0 h1:G6AHpWxTMGY1KyEYoAQ5WTtIekUUvDNjan3ugu60JvE=
 golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/golang/protobuf/proto"
 )
 
 // A Matcher is a representation of a class of values.
@@ -112,6 +114,9 @@ func (e eqMatcher) Matches(x any) bool {
 	x2Val := reflect.ValueOf(x)
 
 	if x1Val.Type().AssignableTo(x2Val.Type()) {
+		if _, isProto := x1Val.Interface().(proto.Message); isProto {
+			return proto.Equal(x1Val.Interface().(proto.Message), x2Val.Interface().(proto.Message))
+		}
 		x1ValConverted := x1Val.Convert(x2Val.Type())
 		return reflect.DeepEqual(x1ValConverted.Interface(), x2Val.Interface())
 	}


### PR DESCRIPTION
Gomock is used with GRPC services. And sometimes there is an error when matching the proto messages. 
Using `proto.Equal` if the arguments are proto messages will be helpful.