### PR TITLE
Fix: wrong print msg when comparing initialized and uninitialized slice

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -463,7 +463,7 @@ func (c *Call) addAction(action func([]any) []any) {
 }
 
 func formatGottenArg(m Matcher, arg any) string {
-	got := fmt.Sprintf("%#v", arg)
+	got := fmt.Sprintf("%#v (%T)", arg, arg)
 	if gs, ok := m.(GotFormatter); ok {
 		got = gs.Got(arg)
 	}

--- a/gomock/call.go
+++ b/gomock/call.go
@@ -463,7 +463,7 @@ func (c *Call) addAction(action func([]any) []any) {
 }
 
 func formatGottenArg(m Matcher, arg any) string {
-	got := fmt.Sprintf("%v (%T)", arg, arg)
+	got := fmt.Sprintf("%#v", arg)
 	if gs, ok := m.(GotFormatter); ok {
 		got = gs.Got(arg)
 	}

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -152,6 +152,7 @@ func (s *Subject) VariadicMethod(arg int, vararg ...string) {}
 type TestStruct struct {
 	Number  int
 	Message string
+	Slice   []int
 }
 
 func (s *Subject) ActOnTestStructMethod(arg TestStruct, arg1 int) int {
@@ -282,20 +283,26 @@ func TestUnexpectedArgValue_FirstArg(t *testing.T) {
 	defer reporter.recoverUnexpectedFatal()
 	subject := new(Subject)
 
-	expectedArg0 := TestStruct{Number: 123, Message: "hello %s"}
+	expectedArg0 := TestStruct{Number: 123, Message: "hello %s", Slice: []int{1, 2}}
 	ctrl.RecordCall(subject, "ActOnTestStructMethod", expectedArg0, 15)
 
 	reporter.assertFatal(func() {
 		// the method argument (of TestStruct type) has 1 unexpected value (for the Message field)
-		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "no message"}, 15)
+		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "no message", Slice: []int{1, 2}}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: {123 no message} (gomock_test.TestStruct)\nWant: is equal to {123 hello %s} (gomock_test.TestStruct)")
+		"Got: gomock_test.TestStruct{Number:123, Message:\"no message\", Slice:[]int{1, 2}}\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}}")
 
 	reporter.assertFatal(func() {
 		// the method argument (of TestStruct type) has 2 unexpected values (for both fields)
-		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 11, Message: "no message"}, 15)
+		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 11, Message: "no message", Slice: []int{1, 2}}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: {11 no message} (gomock_test.TestStruct)\nWant: is equal to {123 hello %s} (gomock_test.TestStruct)")
+		"Got: gomock_test.TestStruct{Number:11, Message:\"no message\", Slice:[]int{1, 2}}\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}}")
+
+	reporter.assertFatal(func() {
+		// the method argument (of TestStruct type) has 1 unexpected values (slice field)
+		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "hello %s", Slice: nil}, 15)
+	}, "Unexpected call to", "doesn't match the argument at index 0",
+		"Got: gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int(nil)}\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}}")
 
 	reporter.assertFatal(func() {
 		// The expected call wasn't made.

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -290,19 +290,19 @@ func TestUnexpectedArgValue_FirstArg(t *testing.T) {
 		// the method argument (of TestStruct type) has 1 unexpected value (for the Message field)
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "no message", Slice: []int{1, 2}}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: gomock_test.TestStruct{Number:123, Message:\"no message\", Slice:[]int{1, 2}}\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}}")
+		"Got: gomock_test.TestStruct{Number:123, Message:\"no message\", Slice:[]int{1, 2}} (gomock_test.TestStruct)\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}} (gomock_test.TestStruct)")
 
 	reporter.assertFatal(func() {
 		// the method argument (of TestStruct type) has 3 unexpected values (for all fields)
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 11, Message: "no message", Slice: []int{}}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: gomock_test.TestStruct{Number:11, Message:\"no message\", Slice:[]int{}}\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}}")
+		"Got: gomock_test.TestStruct{Number:11, Message:\"no message\", Slice:[]int{}} (gomock_test.TestStruct)\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}} (gomock_test.TestStruct)")
 
 	reporter.assertFatal(func() {
 		// the method argument (of TestStruct type) has 1 unexpected values (for slice field)
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "hello %s", Slice: nil}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int(nil)}\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}}")
+		"Got: gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int(nil)} (gomock_test.TestStruct)\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}} (gomock_test.TestStruct)")
 
 	reporter.assertFatal(func() {
 		// The expected call wasn't made.
@@ -828,7 +828,7 @@ func TestVariadicArgumentsGotFormatterTooManyArgsFailure(t *testing.T) {
 	rep.assertFatal(func() {
 		ctrl.Call(s, "VariadicMethod", 0, "2", "3")
 	}, "expected call to", "doesn't match the argument at index 1",
-		"Got: test{[2 3]}\nWant: is equal to 1")
+		"Got: test{[2 3]}\nWant: is equal to \"1\" (string)")
 	ctrl.Call(s, "VariadicMethod", 0, "1")
 	ctrl.Finish()
 }

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -293,13 +293,13 @@ func TestUnexpectedArgValue_FirstArg(t *testing.T) {
 		"Got: gomock_test.TestStruct{Number:123, Message:\"no message\", Slice:[]int{1, 2}}\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}}")
 
 	reporter.assertFatal(func() {
-		// the method argument (of TestStruct type) has 2 unexpected values (for both fields)
-		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 11, Message: "no message", Slice: []int{1, 2}}, 15)
+		// the method argument (of TestStruct type) has 3 unexpected values (for all fields)
+		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 11, Message: "no message", Slice: []int{}}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: gomock_test.TestStruct{Number:11, Message:\"no message\", Slice:[]int{1, 2}}\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}}")
+		"Got: gomock_test.TestStruct{Number:11, Message:\"no message\", Slice:[]int{}}\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}}")
 
 	reporter.assertFatal(func() {
-		// the method argument (of TestStruct type) has 1 unexpected values (slice field)
+		// the method argument (of TestStruct type) has 1 unexpected values (for slice field)
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "hello %s", Slice: nil}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
 		"Got: gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int(nil)}\nWant: is equal to gomock_test.TestStruct{Number:123, Message:\"hello %s\", Slice:[]int{1, 2}}")

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -132,7 +132,7 @@ func (e eqMatcher) Matches(x any) bool {
 }
 
 func (e eqMatcher) String() string {
-	return fmt.Sprintf("is equal to %v (%T)", e.x, e.x)
+	return fmt.Sprintf("is equal to %#v", e.x)
 }
 
 type nilMatcher struct{}

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -132,7 +132,7 @@ func (e eqMatcher) Matches(x any) bool {
 }
 
 func (e eqMatcher) String() string {
-	return fmt.Sprintf("is equal to %#v", e.x)
+	return fmt.Sprintf("is equal to %#v (%T)", e.x, e.x)
 }
 
 type nilMatcher struct{}


### PR DESCRIPTION
## Issue

close: #69

## Tests

I checked all tests are passed with go version 1.19.5 and 1.20.3

- 1.19.5

```bash
❯ go version
go version go1.19.5 darwin/amd64

❯ go test ./...
ok      go.uber.org/mock/gomock 0.998s
?       go.uber.org/mock/gomock/internal/mock_gomock    [no test files]
ok      go.uber.org/mock/mockgen        1.488s
?       go.uber.org/mock/mockgen/internal/tests/add_generate_directive  [no test files]
ok      go.uber.org/mock/mockgen/internal/tests/aux_imports_embedded_interface  0.411s
?       go.uber.org/mock/mockgen/internal/tests/aux_imports_embedded_interface/faux     [no test files]
?       go.uber.org/mock/mockgen/internal/tests/const_array_length      [no test files]
?       go.uber.org/mock/mockgen/internal/tests/copyright_file  [no test files]
?       go.uber.org/mock/mockgen/internal/tests/custom_package_name/client/v1   [no test files]
ok      go.uber.org/mock/mockgen/internal/tests/custom_package_name/greeter     0.668s
?       go.uber.org/mock/mockgen/internal/tests/custom_package_name/validator   [no test files]
?       go.uber.org/mock/mockgen/internal/tests/defined_import_local_name       [no test files]
?       go.uber.org/mock/mockgen/internal/tests/dot_imports     [no test files]
?       go.uber.org/mock/mockgen/internal/tests/empty_interface [no test files]
?       go.uber.org/mock/mockgen/internal/tests/extra_import    [no test files]
ok      go.uber.org/mock/mockgen/internal/tests/generated_identifier_conflict   0.754s
ok      go.uber.org/mock/mockgen/internal/tests/import_embedded_interface       0.370s
?       go.uber.org/mock/mockgen/internal/tests/import_embedded_interface/ersatz        [no test files]
?       go.uber.org/mock/mockgen/internal/tests/import_embedded_interface/faux  [no test files]
?       go.uber.org/mock/mockgen/internal/tests/import_embedded_interface/other/ersatz  [no test files]
?       go.uber.org/mock/mockgen/internal/tests/import_embedded_interface/other/log     [no test files]
?       go.uber.org/mock/mockgen/internal/tests/import_source   [no test files]
?       go.uber.org/mock/mockgen/internal/tests/import_source/definition        [no test files]
?       go.uber.org/mock/mockgen/internal/tests/internal_pkg    [no test files]
?       go.uber.org/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg        [no test files]
?       go.uber.org/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output [no test files]
?       go.uber.org/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output  [no test files]
?       go.uber.org/mock/mockgen/internal/tests/missing_import/output   [no test files]
?       go.uber.org/mock/mockgen/internal/tests/missing_import/source   [no test files]
ok      go.uber.org/mock/mockgen/internal/tests/mock_in_test_package    1.160s [no tests to run]
ok      go.uber.org/mock/mockgen/internal/tests/overlapping_methods     1.379s
ok      go.uber.org/mock/mockgen/internal/tests/panicing_test   1.528s [no tests to run]
?       go.uber.org/mock/mockgen/internal/tests/parenthesized_parameter_type    [no test files]
?       go.uber.org/mock/mockgen/internal/tests/performance/big_interface       [no test files]
?       go.uber.org/mock/mockgen/internal/tests/self_package    [no test files]
ok      go.uber.org/mock/mockgen/internal/tests/test_package    1.715s [no tests to run]
ok      go.uber.org/mock/mockgen/internal/tests/unexported_method       1.911s
?       go.uber.org/mock/mockgen/internal/tests/vendor_dep      [no test files]
?       go.uber.org/mock/mockgen/internal/tests/vendor_dep/source_mock_package  [no test files]
?       go.uber.org/mock/mockgen/internal/tests/vendor_pkg      [no test files]
ok      go.uber.org/mock/mockgen/model  2.080s
ok      go.uber.org/mock/sample 0.589s
ok      go.uber.org/mock/sample/concurrent      2.245s
?       go.uber.org/mock/sample/concurrent/mock [no test files]
?       go.uber.org/mock/sample/imp1    [no test files]
?       go.uber.org/mock/sample/imp2    [no test files]
?       go.uber.org/mock/sample/imp3    [no test files]
?       go.uber.org/mock/sample/imp4    [no test files]
```

- 1.20.3

```bash
❯ go version
go version go1.20.3 darwin/amd64

❯ go test ./...
?       go.uber.org/mock/gomock/internal/mock_gomock    [no test files]
ok      go.uber.org/mock/gomock 0.308s
?       go.uber.org/mock/mockgen/internal/tests/add_generate_directive  [no test files]
?       go.uber.org/mock/mockgen/internal/tests/aux_imports_embedded_interface/faux     [no test files]
?       go.uber.org/mock/mockgen/internal/tests/const_array_length      [no test files]
?       go.uber.org/mock/mockgen/internal/tests/copyright_file  [no test files]
?       go.uber.org/mock/mockgen/internal/tests/custom_package_name/client/v1   [no test files]
?       go.uber.org/mock/mockgen/internal/tests/custom_package_name/validator   [no test files]
?       go.uber.org/mock/mockgen/internal/tests/defined_import_local_name       [no test files]
?       go.uber.org/mock/mockgen/internal/tests/dot_imports     [no test files]
?       go.uber.org/mock/mockgen/internal/tests/empty_interface [no test files]
?       go.uber.org/mock/mockgen/internal/tests/extra_import    [no test files]
?       go.uber.org/mock/mockgen/internal/tests/import_embedded_interface/ersatz        [no test files]
?       go.uber.org/mock/mockgen/internal/tests/import_embedded_interface/faux  [no test files]
?       go.uber.org/mock/mockgen/internal/tests/import_embedded_interface/other/ersatz  [no test files]
?       go.uber.org/mock/mockgen/internal/tests/import_embedded_interface/other/log     [no test files]
?       go.uber.org/mock/mockgen/internal/tests/import_source   [no test files]
?       go.uber.org/mock/mockgen/internal/tests/import_source/definition        [no test files]
?       go.uber.org/mock/mockgen/internal/tests/internal_pkg    [no test files]
?       go.uber.org/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg        [no test files]
?       go.uber.org/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output [no test files]
?       go.uber.org/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output  [no test files]
?       go.uber.org/mock/mockgen/internal/tests/missing_import/output   [no test files]
?       go.uber.org/mock/mockgen/internal/tests/missing_import/source   [no test files]
?       go.uber.org/mock/mockgen/internal/tests/parenthesized_parameter_type    [no test files]
?       go.uber.org/mock/mockgen/internal/tests/performance/big_interface       [no test files]
?       go.uber.org/mock/mockgen/internal/tests/self_package    [no test files]
?       go.uber.org/mock/mockgen/internal/tests/vendor_dep      [no test files]
?       go.uber.org/mock/mockgen/internal/tests/vendor_dep/source_mock_package  [no test files]
?       go.uber.org/mock/mockgen/internal/tests/vendor_pkg      [no test files]
?       go.uber.org/mock/sample/concurrent/mock [no test files]
?       go.uber.org/mock/sample/imp1    [no test files]
?       go.uber.org/mock/sample/imp2    [no test files]
?       go.uber.org/mock/sample/imp3    [no test files]
?       go.uber.org/mock/sample/imp4    [no test files]
ok      go.uber.org/mock/mockgen        0.992s
ok      go.uber.org/mock/mockgen/internal/tests/aux_imports_embedded_interface  0.541s
ok      go.uber.org/mock/mockgen/internal/tests/custom_package_name/greeter     0.424s
ok      go.uber.org/mock/mockgen/internal/tests/generated_identifier_conflict   0.641s
ok      go.uber.org/mock/mockgen/internal/tests/import_embedded_interface       0.813s
ok      go.uber.org/mock/mockgen/internal/tests/mock_in_test_package    0.676s [no tests to run]
ok      go.uber.org/mock/mockgen/internal/tests/overlapping_methods     0.798s
ok      go.uber.org/mock/mockgen/internal/tests/panicing_test   0.857s [no tests to run]
ok      go.uber.org/mock/mockgen/internal/tests/test_package    0.935s [no tests to run]
ok      go.uber.org/mock/mockgen/internal/tests/unexported_method       1.017s
ok      go.uber.org/mock/mockgen/model  0.996s
ok      go.uber.org/mock/sample 1.071s
ok      go.uber.org/mock/sample/concurrent      1.108s
```