### PR TITLE
Undo deprecation of Controller.Finish()

### DIFF
--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -236,9 +236,6 @@ func (ctrl *Controller) Call(receiver any, method string, args ...any) []any {
 
 // Finish checks to see if all the methods that were expected to be called were called.
 // It is not idempotent and therefore can only be invoked once.
-//
-// Deprecated: Calling this function in test methods is not required starting from Go 1.14.
-// It will be called automatically from a self registered [testing.T.Cleanup] function.
 func (ctrl *Controller) Finish() {
 	// If we're currently panicking, probably because this is a deferred call.
 	// This must be recovered in the deferred function.


### PR DESCRIPTION
We're about to release a new version, and we need to reach some more consensus on this decision. Undoing this deprecation for the time being for v0.3.0 release.

Ref: https://github.com/uber-go/mock/discussions/84.