### PR TITLE
goreleaser config - fix owner

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,7 @@
 ---
 release:
   github:
-    owner: uber
+    owner: uber-go
     name: mock
 
 builds:
@@ -30,6 +30,7 @@ archives:
    files:
      - LICENSE
      - README.md
+
 checksum:
 snapshot:
   name_template: "snap-{{ .Commit }}"


### PR DESCRIPTION
binary uploads are failing because we moved this repo from the `uber` GitHub org to `uber-go` GitHub org, so uploads are getting 307 response.