### PR TITLE
fix: race condition on Controller.Satisfied

### DIFF
--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -246,6 +246,8 @@ func (ctrl *Controller) Finish() {
 // Satisfied returns whether all expected calls bound to this Controller have been satisfied.
 // Calling Finish is then guaranteed to not fail due to missing calls.
 func (ctrl *Controller) Satisfied() bool {
+	ctrl.mu.Lock()
+	defer ctrl.mu.Unlock()
 	return ctrl.expectedCalls.Satisfied()
 }
 

--- a/sample/concurrent/README.md
+++ b/sample/concurrent/README.md
@@ -1,0 +1,9 @@
+# Concurrent
+
+This directory contains an example of executing mock calls concurrently.
+
+To run the test,
+
+```bash
+go test -race go.uber.org/mock/sample/concurrent
+```


### PR DESCRIPTION
This PR is a proposal to add `mutex.Lock` on `Controller.Satisfied` to solve a race condition that can arise when two goroutines are involved in checking whether mock conditions have been satisfied.

The use case is illustrated in the `sample/concurrent` package - what I'm hoping to accomplish is where the test scenario contains one goroutine that runs indefinitely that calls mocked functions, I would like to use `Satisfied` as one of the conditions to trigger test assertions.

Tests added in `sample/concurrent` fails data race check without this change:
```
$ go test -race go.uber.org/mock/sample/concurrent
==================
WARNING: DATA RACE
Read at 0x00c000156350 by goroutine 9:
  go.uber.org/mock/gomock.(*Call).satisfied()
      /Users/dave/work/src/mock/gomock/call.go:307 +0x204
  go.uber.org/mock/gomock.callSet.Satisfied()
      /Users/dave/work/src/mock/gomock/callset.go:157 +0x247
  go.uber.org/mock/gomock.(*Controller).Satisfied()
      /Users/dave/work/src/mock/gomock/controller.go:249 +0x244
  go.uber.org/mock/sample/concurrent.waitForMocks()
      /Users/dave/work/src/mock/sample/concurrent/concurrent_test.go:35 +0x247
  go.uber.org/mock/sample/concurrent.TestCancelWhenMocksSatisfied()
      /Users/dave/work/src/mock/sample/concurrent/concurrent_test.go:85 +0x33b
  testing.tRunner()
      /usr/local/Cellar/go/1.20.3/libexec/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /usr/local/Cellar/go/1.20.3/libexec/src/testing/testing.go:1629 +0x47

Previous write at 0x00c000156350 by goroutine 10:
  go.uber.org/mock/gomock.(*Call).call()
      /Users/dave/work/src/mock/gomock/call.go:433 +0x611
  go.uber.org/mock/gomock.(*Controller).Call.func1()
      /Users/dave/work/src/mock/gomock/controller.go:220 +0x5d6
  go.uber.org/mock/gomock.(*Controller).Call()
      /Users/dave/work/src/mock/gomock/controller.go:225 +0xcd
  go.uber.org/mock/sample/concurrent/mock.(*MockMath).Sum()
      /Users/dave/work/src/mock/sample/concurrent/mock/concurrent_mock.go:43 +0x16d
  go.uber.org/mock/sample/concurrent.TestCancelWhenMocksSatisfied.func1()
      /Users/dave/work/src/mock/sample/concurrent/concurrent_test.go:76 +0x4c

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.20.3/libexec/src/testing/testing.go:1629 +0x805
  testing.runTests.func1()
      /usr/local/Cellar/go/1.20.3/libexec/src/testing/testing.go:2036 +0x8d
  testing.tRunner()
      /usr/local/Cellar/go/1.20.3/libexec/src/testing/testing.go:1576 +0x216
  testing.runTests()
      /usr/local/Cellar/go/1.20.3/libexec/src/testing/testing.go:2034 +0x87c
  testing.(*M).Run()
      /usr/local/Cellar/go/1.20.3/libexec/src/testing/testing.go:1906 +0xb44
  main.main()
      _testmain.go:51 +0x2e9

Goroutine 10 (running) created at:
  go.uber.org/mock/sample/concurrent.TestCancelWhenMocksSatisfied()
      /Users/dave/work/src/mock/sample/concurrent/concurrent_test.go:74 +0x324
  testing.tRunner()
      /usr/local/Cellar/go/1.20.3/libexec/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /usr/local/Cellar/go/1.20.3/libexec/src/testing/testing.go:1629 +0x47
==================
```

