### PR TITLE
Add archive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,23 @@ go install go.uber.org/mock/mockgen@latest
 
 ## Running mockgen
 
-`mockgen` has two modes of operation: source and reflect.
+`mockgen` has three modes of operation: archive, source and reflect.
+
+### Archive mode
+
+Archive mode generates mock interfaces from a package archive
+file (.a). It is enabled by using the -archive flag, the import
+path is also needed as a non-flag argument. No other flags are
+required.
+
+Example:
+
+```bash
+# Build the package to a archive.
+go build -o pkg.a database/sql/driver
+
+mockgen -archive=pkg.a database/sql/driver
+```
 
 ### Source mode
 
@@ -65,6 +81,8 @@ mockgen . Conn,Driver
 The `mockgen` command is used to generate source code for a mock
 class given a Go source file containing interfaces to be mocked.
 It supports the following flags:
+
+- `-archive`: A package archive file containing interfaces to be mocked.
 
 - `-source`: A file containing interfaces to be mocked.
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ go install go.uber.org/mock/mockgen@latest
 ### Archive mode
 
 Archive mode generates mock interfaces from a package archive
-file (.a). It is enabled by using the -archive flag, the import
-path is also needed as a non-flag argument. No other flags are
-required.
+file (.a). It is enabled by using the -archive flag and two
+non-flag arguments: an import path, and a comma-separated
+list of symbols.
 
 Example:
 

--- a/mockgen/archive.go
+++ b/mockgen/archive.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"go/token"
+	"go/types"
+	"log"
+	"os"
+
+	"go.uber.org/mock/mockgen/model"
+
+	"golang.org/x/tools/go/gcexportdata"
+)
+
+func archiveMode(importpath, archive string) (*model.Package, error) {
+	f, err := os.Open(archive)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	r, err := gcexportdata.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("read export data %q: %v", archive, err)
+	}
+
+	fset := token.NewFileSet()
+	imports := make(map[string]*types.Package)
+	tp, err := gcexportdata.Read(r, fset, imports, importpath)
+	if err != nil {
+		return nil, err
+	}
+
+	pkg := &model.Package{
+		Name:    tp.Name(),
+		PkgPath: tp.Path(),
+	}
+	for _, name := range tp.Scope().Names() {
+		m := tp.Scope().Lookup(name)
+		tn, ok := m.(*types.TypeName)
+		if !ok {
+			continue
+		}
+		ti, ok := tn.Type().Underlying().(*types.Interface)
+		if !ok {
+			continue
+		}
+		it, err := model.InterfaceFromGoTypesType(ti)
+		if err != nil {
+			log.Fatal(err)
+		}
+		it.Name = m.Name()
+		pkg.Interfaces = append(pkg.Interfaces, it)
+	}
+	return pkg, nil
+}

--- a/mockgen/archive.go
+++ b/mockgen/archive.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/tools/go/gcexportdata"
 )
 
-func archiveMode(importpath, archive string) (*model.Package, error) {
+func archiveMode(importPath string, symbols []string, archive string) (*model.Package, error) {
 	f, err := os.Open(archive)
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func archiveMode(importpath, archive string) (*model.Package, error) {
 
 	fset := token.NewFileSet()
 	imports := make(map[string]*types.Package)
-	tp, err := gcexportdata.Read(r, fset, imports, importpath)
+	tp, err := gcexportdata.Read(r, fset, imports, importPath)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func archiveMode(importpath, archive string) (*model.Package, error) {
 		Name:    tp.Name(),
 		PkgPath: tp.Path(),
 	}
-	for _, name := range tp.Scope().Names() {
+	for _, name := range symbols {
 		m := tp.Scope().Lookup(name)
 		tn, ok := m.(*types.TypeName)
 		if !ok {

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -247,7 +247,7 @@ Example:
 
 Archive mode generates mock interfaces from a package archive
 file (.a). It is enabled by using the -archive flag and two 
-two non-flag arguments: an import path, and a comma-separated 
+non-flag arguments: an import path, and a comma-separated 
 list of symbols.
 Example:
 	mockgen -archive=pkg.a database/sql/driver Conn,Driver

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -85,12 +85,6 @@ func main() {
 	var packageName string
 	if *source != "" {
 		pkg, err = sourceMode(*source)
-	} else if *archive != "" {
-		if flag.NArg() != 1 {
-			usage()
-			log.Fatal("Expected exactly one argument")
-		}
-		pkg, err = archiveMode(flag.Arg(0), *archive)
 	} else {
 		if flag.NArg() != 2 {
 			usage()
@@ -98,17 +92,21 @@ func main() {
 		}
 		packageName = flag.Arg(0)
 		interfaces := strings.Split(flag.Arg(1), ",")
-		if packageName == "." {
-			dir, err := os.Getwd()
-			if err != nil {
-				log.Fatalf("Get current directory failed: %v", err)
+		if *archive != "" {
+			pkg, err = archiveMode(packageName, interfaces, *archive)
+		} else {
+			if packageName == "." {
+				dir, err := os.Getwd()
+				if err != nil {
+					log.Fatalf("Get current directory failed: %v", err)
+				}
+				packageName, err = packageNameOfDir(dir)
+				if err != nil {
+					log.Fatalf("Parse package name failed: %v", err)
+				}
 			}
-			packageName, err = packageNameOfDir(dir)
-			if err != nil {
-				log.Fatalf("Parse package name failed: %v", err)
-			}
+			pkg, err = reflectMode(packageName, interfaces)
 		}
-		pkg, err = reflectMode(packageName, interfaces)
 	}
 	if err != nil {
 		log.Fatalf("Loading input failed: %v", err)
@@ -234,13 +232,6 @@ func usage() {
 
 const usageText = `mockgen has three modes of operation: archive, source and reflect.
 
-Archive mode generates mock interfaces from a package archive
-file (.a). It is enabled by using the -archive flag, the import
-path is also needed as a non-flag argument. No other flags are
-required.
-Example:
-	mockgen -archive=pkg.a importpath
-
 Source mode generates mock interfaces from a source file.
 It is enabled by using the -source flag. Other flags that
 may be useful in this mode are -imports and -aux_files.
@@ -253,6 +244,13 @@ by passing two non-flag arguments: an import path, and a
 comma-separated list of symbols.
 Example:
 	mockgen database/sql/driver Conn,Driver
+
+Archive mode generates mock interfaces from a package archive
+file (.a). It is enabled by using the -archive flag and two 
+two non-flag arguments: an import path, and a comma-separated 
+list of symbols.
+Example:
+	mockgen -archive=pkg.a database/sql/driver Conn,Driver
 
 `
 

--- a/mockgen/model/model_gotypes.go
+++ b/mockgen/model/model_gotypes.go
@@ -42,8 +42,7 @@ func funcArgsFromGoTypesType(t *types.Signature) (in []*Parameter, variadic *Par
 		in = append(in, p)
 	}
 	if t.Variadic() {
-		p, err = parameterFromGoTypesType(t.Params().At(nin), true)
-		if err != nil {
+		if p, err = parameterFromGoTypesType(t.Params().At(nin), true); err != nil {
 			return
 		}
 		variadic = p

--- a/mockgen/model/model_gotypes.go
+++ b/mockgen/model/model_gotypes.go
@@ -1,0 +1,164 @@
+package model
+
+import (
+	"fmt"
+	"go/types"
+)
+
+// InterfaceFromGoTypesType returns a pointer to an interface for the
+// given reflection interface type.
+func InterfaceFromGoTypesType(it *types.Interface) (*Interface, error) {
+	intf := &Interface{}
+
+	for i := 0; i < it.NumMethods(); i++ {
+		mt := it.Method(i)
+		// TODO: need to skip unexported methods? or just raise an error?
+		m := &Method{
+			Name: mt.Name(),
+		}
+
+		var err error
+		m.In, m.Variadic, m.Out, err = funcArgsFromGoTypesType(mt.Type().(*types.Signature))
+		if err != nil {
+			return nil, err
+		}
+
+		intf.AddMethod(m)
+	}
+
+	return intf, nil
+}
+
+func funcArgsFromGoTypesType(t *types.Signature) (in []*Parameter, variadic *Parameter, out []*Parameter, err error) {
+	nin := t.Params().Len()
+	if t.Variadic() {
+		nin--
+	}
+	var p *Parameter
+	for i := 0; i < nin; i++ {
+		p, err = parameterFromGoTypesType(t.Params().At(i), false)
+		if err != nil {
+			return
+		}
+		in = append(in, p)
+	}
+	if t.Variadic() {
+		p, err = parameterFromGoTypesType(t.Params().At(nin), true)
+		if err != nil {
+			return
+		}
+		variadic = p
+	}
+	for i := 0; i < t.Results().Len(); i++ {
+		p, err = parameterFromGoTypesType(t.Results().At(i), false)
+		if err != nil {
+			return
+		}
+		out = append(out, p)
+	}
+	return
+}
+
+func parameterFromGoTypesType(v *types.Var, variadic bool) (*Parameter, error) {
+	t := v.Type()
+	if variadic {
+		t = t.(*types.Slice).Elem()
+	}
+	tt, err := typeFromGoTypesType(t)
+	if err != nil {
+		return nil, err
+	}
+	return &Parameter{Name: v.Name(), Type: tt}, nil
+}
+
+func typeFromGoTypesType(t types.Type) (Type, error) {
+	// Hack workaround for https://golang.org/issue/3853.
+	// This explicit check should not be necessary.
+	// if t == byteType {
+	// 	return PredeclaredType("byte"), nil
+	// }
+
+	if t, ok := t.(*types.Named); ok {
+		tn := t.Obj()
+		if tn.Pkg() == nil {
+			return PredeclaredType(tn.Name()), nil
+		}
+		return &NamedType{
+			Package: tn.Pkg().Path(),
+			Type:    tn.Name(),
+		}, nil
+	}
+
+	// only unnamed or predeclared types after here
+
+	// Lots of types have element types. Let's do the parsing and error checking for all of them.
+	var elemType Type
+	if t, ok := t.(interface{ Elem() types.Type }); ok {
+		var err error
+		elemType, err = typeFromGoTypesType(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	switch t := t.(type) {
+	case *types.Array:
+		return &ArrayType{
+			Len:  int(t.Len()),
+			Type: elemType,
+		}, nil
+	case *types.Basic:
+		return PredeclaredType(t.String()), nil
+	case *types.Chan:
+		var dir ChanDir
+		switch t.Dir() {
+		case types.RecvOnly:
+			dir = RecvDir
+		case types.SendOnly:
+			dir = SendDir
+		}
+		return &ChanType{
+			Dir:  dir,
+			Type: elemType,
+		}, nil
+	case *types.Signature:
+		in, variadic, out, err := funcArgsFromGoTypesType(t)
+		if err != nil {
+			return nil, err
+		}
+		return &FuncType{
+			In:       in,
+			Out:      out,
+			Variadic: variadic,
+		}, nil
+	case *types.Interface:
+		if t.NumMethods() == 0 {
+			return PredeclaredType("interface{}"), nil
+		}
+	case *types.Map:
+		kt, err := typeFromGoTypesType(t.Key())
+		if err != nil {
+			return nil, err
+		}
+		return &MapType{
+			Key:   kt,
+			Value: elemType,
+		}, nil
+	case *types.Pointer:
+		return &PointerType{
+			Type: elemType,
+		}, nil
+	case *types.Slice:
+		return &ArrayType{
+			Len:  -1,
+			Type: elemType,
+		}, nil
+	case *types.Struct:
+		if t.NumFields() == 0 {
+			return PredeclaredType("struct{}"), nil
+		}
+	}
+
+	// TODO: Struct, UnsafePointer
+	return nil, fmt.Errorf("can't yet turn %v (%T) into a model.Type", t.String(), t)
+}

--- a/mockgen/model/model_gotypes.go
+++ b/mockgen/model/model_gotypes.go
@@ -36,8 +36,7 @@ func funcArgsFromGoTypesType(t *types.Signature) (in []*Parameter, variadic *Par
 	}
 	var p *Parameter
 	for i := 0; i < nin; i++ {
-		p, err = parameterFromGoTypesType(t.Params().At(i), false)
-		if err != nil {
+		if p, err = parameterFromGoTypesType(t.Params().At(i), false); err != nil {
 			return
 		}
 		in = append(in, p)

--- a/mockgen/model/model_gotypes.go
+++ b/mockgen/model/model_gotypes.go
@@ -157,8 +157,8 @@ func typeFromGoTypesType(t types.Type) (Type, error) {
 		if t.NumFields() == 0 {
 			return PredeclaredType("struct{}"), nil
 		}
+		// TODO: UnsafePointer
 	}
 
-	// TODO: Struct, UnsafePointer
 	return nil, fmt.Errorf("can't yet turn %v (%T) into a model.Type", t.String(), t)
 }


### PR DESCRIPTION
This ports from https://github.com/golang/mock/pull/633 with an additional argument to take a list of interfaces to mock.

The archive mode allows us to generate mocks in Bazel without having to compile a package again.