### PR TITLE
chore: delete obsolete // +build lines

### DIFF
--- a/mockgen/generic_go118.go
+++ b/mockgen/generic_go118.go
@@ -6,7 +6,6 @@
 // limitations under the License.
 
 //go:build go1.18
-// +build go1.18
 
 package main
 

--- a/mockgen/generic_notgo118.go
+++ b/mockgen/generic_notgo118.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !go1.18
-// +build !go1.18
 
 package main
 

--- a/mockgen/internal/tests/panicing_test/panic_test.go
+++ b/mockgen/internal/tests/panicing_test/panic_test.go
@@ -1,5 +1,4 @@
 //go:build panictest
-// +build panictest
 
 // Copyright 2020 Google LLC
 //


### PR DESCRIPTION
This PR removes outdated `// +build` build constraints. I used `go fix ./...` to remove the `// +build` lines that have become obsolete in Go 1.18. See https://go.dev/doc/go1.18#go-build-lines.