### PR TITLE
Correct typos in comments, test, and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - [#93][]: Ignore interfaces that contain type constraints.
 - [#101][]: Fix race condition on Controller.Satisfied.
 - [#121][]: Fix paths for windows.
-- [#127][]: Propogate -mock_names to Recorder and ReturnCall types.
+- [#127][]: Propagate -mock_names to Recorder and ReturnCall types.
 - [#132][]: Sanitize "any" package names.
 
 [#63]: https://github.com/uber-go/mock/pull/63

--- a/gomock/call_test.go
+++ b/gomock/call_test.go
@@ -635,7 +635,7 @@ func TestInOrder(t *testing.T) {
 			t.Fatalf("expected 0 preReq in c1, found %d", len(c1.preReqs))
 		}
 	})
-	t.Run("panic when the argument isn't a *Call or has one embeded", func(t *testing.T) {
+	t.Run("panic when the argument isn't a *Call or has one embedded", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r == nil {
 				t.Error("expected InOrder to panic")

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -210,8 +210,8 @@ func (ctrl *Controller) Call(receiver any, method string, args ...any) []any {
 		}
 
 		// Two things happen here:
-		// * the matching call no longer needs to check prerequite calls,
-		// * and the prerequite calls are no longer expected, so remove them.
+		// * the matching call no longer needs to check prerequisite calls,
+		// * and the prerequisite calls are no longer expected, so remove them.
 		preReqCalls := expected.dropPrereqs()
 		for _, preReqCall := range preReqCalls {
 			ctrl.expectedCalls.Remove(preReqCall)

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -878,7 +878,7 @@ func TestOrderedCallsWithPreReqMaxUnbounded(t *testing.T) {
 			ctrl.Call(subjectOne, "FooMethod", "1")
 			ctrl.Call(subjectOne, "FooMethod", "1")
 
-			// But calling something that has it as a prerequite should remove it from
+			// But calling something that has it as a prerequisite should remove it from
 			// the expected call set. This allows tests to ensure that FooMethod("1") is
 			// *not* called after FooMethod("2").
 			ctrl.Call(subjectTwo, "FooMethod", "2")


### PR DESCRIPTION
This PR fixes typos and spelling errors in code and documentation.