### PR TITLE
Drop root go.mod dependencies from dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,11 +1,6 @@
 version: 2
 updates:
 - package-ecosystem: "gomod"
-  directory: "/"
-  schedule:
-    interval: "daily"
-  open-pull-requests-limit: 5
-- package-ecosystem: "gomod"
   directory: "/tools"
   schedule:
     interval: "daily"


### PR DESCRIPTION
In order to use a Go library, users must upgrade their dependencies to be at least as up-to-date as those listed in the library's `go.mod`. As @abhinav pointed out, using dependabot to then keep our dependencies up-to-date all the time will cause any users of this library to have to keep theirs up-to-date all the time as well, when this isn't strictly necessary due to Go's heavy backwards compatibility culture.

Remove the section referring to the root's `go.mod` so that we can instead only upgrade dependencies when necessary to avoid too much churn with users of the library.