### PR TITLE
Enable integration tests when go version is not 1.18

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.21.x, 1.22.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,10 +3,6 @@
 
 set -euo pipefail
 
-if [[ $(go version) != *"go1.18"* ]]; then
-  exit 0
-fi
-
 for i in $(find $PWD -name go.mod); do
   pushd $(dirname $i)
   go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/mock
 
-go 1.20
+go 1.21
 
 require (
 	golang.org/x/mod v0.15.0

--- a/mockgen/internal/tests/generics/go.mod
+++ b/mockgen/internal/tests/generics/go.mod
@@ -1,6 +1,8 @@
 module go.uber.org/mock/mockgen/internal/tests/generics
 
-go 1.19
+go 1.21
+
+toolchain go1.21.2
 
 require (
 	go.uber.org/mock v1.6.0

--- a/mockgen/internal/tests/typed/go.mod
+++ b/mockgen/internal/tests/typed/go.mod
@@ -1,6 +1,8 @@
 module go.uber.org/mock/mockgen/internal/tests/typed
 
-go 1.18
+go 1.21
+
+toolchain go1.21.2
 
 replace go.uber.org/mock => ../../../..
 


### PR DESCRIPTION
- delete a wrong filter which disabled the tests https://github.com/uber-go/mock/blob/c9ae04c6e772f065390ee33052c1ed0ce753b897/.github/workflows/test.yaml#L18
- update the go version as README "go.uber.org/mock supports all Go versions supported by the official [Go Release Policy](https://go.dev/doc/devel/release#policy). That is, the two most recent releases of Go."