### PR TITLE
fix: adds the correct matching of proto.Message types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	golang.org/x/mod v0.15.0
 	golang.org/x/tools v0.18.0
+	google.golang.org/protobuf v1.34.1
 )
 
 require github.com/yuin/goldmark v1.4.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/mod v0.15.0 h1:SernR4v+D55NyBH2QiEQrlBAnj1ECL6AGrA5+dPaMY8=
 golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/tools v0.18.0 h1:k8NLag8AGHnn+PHbl7g43CtqZAwG60vZkLqgyZgIHgQ=
 golang.org/x/tools v0.18.0/go.mod h1:GL7B4CwcLLeo59yx/9UWWuNOW1n3VZ4f5axWfML7Lcg=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
+google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -16,6 +16,7 @@ package gomock
 
 import (
 	"fmt"
+	"google.golang.org/protobuf/proto"
 	"reflect"
 	"regexp"
 	"strings"
@@ -123,6 +124,11 @@ func (e eqMatcher) Matches(x any) bool {
 	// Check if types assignable and convert them to common type
 	x1Val := reflect.ValueOf(e.x)
 	x2Val := reflect.ValueOf(x)
+
+	if x1Val.Type().Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) &&
+		x2Val.Type().Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) {
+		return proto.Equal(e.x.(proto.Message), x.(proto.Message))
+	}
 
 	if x1Val.Type().AssignableTo(x2Val.Type()) {
 		x1ValConverted := x1Val.Convert(x2Val.Type())

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -125,12 +125,11 @@ func (e eqMatcher) Matches(x any) bool {
 	x1Val := reflect.ValueOf(e.x)
 	x2Val := reflect.ValueOf(x)
 
-	if x1Val.Type().Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) &&
-		x2Val.Type().Implements(reflect.TypeOf((*proto.Message)(nil)).Elem()) {
-		return proto.Equal(e.x.(proto.Message), x.(proto.Message))
-	}
-
 	if x1Val.Type().AssignableTo(x2Val.Type()) {
+		if _, isProto := x1Val.Interface().(proto.Message); isProto {
+			return proto.Equal(e.x.(proto.Message), x.(proto.Message))
+		}
+
 		x1ValConverted := x1Val.Convert(x2Val.Type())
 		return reflect.DeepEqual(x1ValConverted.Interface(), x2Val.Interface())
 	}


### PR DESCRIPTION
Types generated by protocol buffers are incompatible with reflect.DeepEqual and needs to use proto.Equal instead. This PR modifies the matcher behavior so that proto.Equal is used if both the compared types satisfy the proto.Message interface.