### PR TITLE
chore: go generate for ISGOMOCK method

### DIFF
--- a/gomock/example_test.go
+++ b/gomock/example_test.go
@@ -12,6 +12,7 @@ import (
 
 type Foo interface {
 	Bar(string) string
+	String() string
 }
 
 func ExampleCall_DoAndReturn_latency() {

--- a/gomock/internal/mock_gomock/mock_matcher.go
+++ b/gomock/internal/mock_gomock/mock_matcher.go
@@ -38,6 +38,11 @@ func (m *MockMatcher) EXPECT() *MockMatcherMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockMatcher) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Matches mocks base method.
 func (m *MockMatcher) Matches(arg0 any) bool {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/add_generate_directive/mock.go
+++ b/mockgen/internal/tests/add_generate_directive/mock.go
@@ -40,6 +40,11 @@ func (m *MockFoo) EXPECT() *MockFooMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockFoo) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Bar mocks base method.
 func (m *MockFoo) Bar(arg0 []string, arg1 chan<- Message) {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/const_array_length/mock.go
+++ b/mockgen/internal/tests/const_array_length/mock.go
@@ -38,6 +38,11 @@ func (m *MockI) EXPECT() *MockIMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockI) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Bar mocks base method.
 func (m *MockI) Bar() [2]int {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/copyright_file/mock.go
+++ b/mockgen/internal/tests/copyright_file/mock.go
@@ -42,3 +42,8 @@ func NewMockEmpty(ctrl *gomock.Controller) *MockEmpty {
 func (m *MockEmpty) EXPECT() *MockEmptyMockRecorder {
 	return m.recorder
 }
+
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockEmpty) ISGOMOCK() struct{} {
+	return struct{}{}
+}

--- a/mockgen/internal/tests/custom_package_name/greeter/greeter_mock_test.go
+++ b/mockgen/internal/tests/custom_package_name/greeter/greeter_mock_test.go
@@ -39,6 +39,11 @@ func (m *MockInputMaker) EXPECT() *MockInputMakerMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockInputMaker) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // MakeInput mocks base method.
 func (m *MockInputMaker) MakeInput() client.GreetInput {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/defined_import_local_name/mock.go
+++ b/mockgen/internal/tests/defined_import_local_name/mock.go
@@ -40,6 +40,11 @@ func (m *MockWithImports) EXPECT() *MockWithImportsMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockWithImports) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Method1 mocks base method.
 func (m *MockWithImports) Method1() b_mock.Buffer {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/dot_imports/mock.go
+++ b/mockgen/internal/tests/dot_imports/mock.go
@@ -41,6 +41,11 @@ func (m *MockWithDotImports) EXPECT() *MockWithDotImportsMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockWithDotImports) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Method1 mocks base method.
 func (m *MockWithDotImports) Method1() Request {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/empty_interface/mock.go
+++ b/mockgen/internal/tests/empty_interface/mock.go
@@ -35,3 +35,8 @@ func NewMockEmpty(ctrl *gomock.Controller) *MockEmpty {
 func (m *MockEmpty) EXPECT() *MockEmptyMockRecorder {
 	return m.recorder
 }
+
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockEmpty) ISGOMOCK() struct{} {
+	return struct{}{}
+}

--- a/mockgen/internal/tests/exclude/mock.go
+++ b/mockgen/internal/tests/exclude/mock.go
@@ -38,6 +38,11 @@ func (m *MockGenerateMockForMe) EXPECT() *MockGenerateMockForMeMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockGenerateMockForMe) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // B mocks base method.
 func (m *MockGenerateMockForMe) B() int {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/extra_import/mock.go
+++ b/mockgen/internal/tests/extra_import/mock.go
@@ -38,6 +38,11 @@ func (m *MockFoo) EXPECT() *MockFooMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockFoo) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Bar mocks base method.
 func (m *MockFoo) Bar(arg0 []string, arg1 chan<- Message) {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/generated_identifier_conflict/bugreport_mock.go
+++ b/mockgen/internal/tests/generated_identifier_conflict/bugreport_mock.go
@@ -38,6 +38,11 @@ func (m *MockExample) EXPECT() *MockExampleMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockExample) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Method mocks base method.
 func (m_2 *MockExample) Method(_m, _mr, m, mr int) {
 	m_2.ctrl.T.Helper()

--- a/mockgen/internal/tests/import_embedded_interface/bugreport_mock.go
+++ b/mockgen/internal/tests/import_embedded_interface/bugreport_mock.go
@@ -40,6 +40,11 @@ func (m *MockSource) EXPECT() *MockSourceMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockSource) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Bar mocks base method.
 func (m *MockSource) Bar() Baz {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/import_embedded_interface/net_mock.go
+++ b/mockgen/internal/tests/import_embedded_interface/net_mock.go
@@ -39,6 +39,11 @@ func (m *MockNet) EXPECT() *MockNetMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockNet) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Header mocks base method.
 func (m *MockNet) Header() http.Header {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/import_source/definition/source_mock.go
+++ b/mockgen/internal/tests/import_source/definition/source_mock.go
@@ -38,6 +38,11 @@ func (m *MockS) EXPECT() *MockSMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockS) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // F mocks base method.
 func (m *MockS) F(arg0 X) {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/import_source/source_mock.go
+++ b/mockgen/internal/tests/import_source/source_mock.go
@@ -39,6 +39,11 @@ func (m *MockS) EXPECT() *MockSMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockS) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // F mocks base method.
 func (m *MockS) F(arg0 source.X) {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/mock.go
+++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/mock.go
@@ -39,6 +39,11 @@ func (m *MockArg) EXPECT() *MockArgMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockArg) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Foo mocks base method.
 func (m *MockArg) Foo() int {
 	m.ctrl.T.Helper()
@@ -74,6 +79,11 @@ func NewMockIntf(ctrl *gomock.Controller) *MockIntf {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIntf) EXPECT() *MockIntfMockRecorder {
 	return m.recorder
+}
+
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockIntf) ISGOMOCK() struct{} {
+	return struct{}{}
 }
 
 // F mocks base method.

--- a/mockgen/internal/tests/missing_import/output/source_mock.go
+++ b/mockgen/internal/tests/missing_import/output/source_mock.go
@@ -39,6 +39,11 @@ func (m *MockBar) EXPECT() *MockBarMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockBar) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Baz mocks base method.
 func (m *MockBar) Baz(arg0 source.Foo) {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/mock_in_test_package/mock_test.go
+++ b/mockgen/internal/tests/mock_in_test_package/mock_test.go
@@ -39,6 +39,11 @@ func (m *MockFinder) EXPECT() *MockFinderMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockFinder) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Add mocks base method.
 func (m *MockFinder) Add(u users.User) {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/mock_name/mocks/post_service.go
+++ b/mockgen/internal/tests/mock_name/mocks/post_service.go
@@ -40,6 +40,11 @@ func (m *PostServiceMock) EXPECT() *PostServiceMockMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *PostServiceMock) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Create mocks base method.
 func (m *PostServiceMock) Create(arg0, arg1 string, arg2 *user.User) (*post.Post, error) {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/mock_name/mocks/user_service.go
+++ b/mockgen/internal/tests/mock_name/mocks/user_service.go
@@ -39,6 +39,11 @@ func (m *UserServiceMock) EXPECT() *UserServiceMockMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *UserServiceMock) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Create mocks base method.
 func (m *UserServiceMock) Create(arg0 string) (*user.User, error) {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/overlapping_methods/mock.go
+++ b/mockgen/internal/tests/overlapping_methods/mock.go
@@ -38,6 +38,11 @@ func (m *MockReadWriteCloser) EXPECT() *MockReadWriteCloserMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockReadWriteCloser) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Close mocks base method.
 func (m *MockReadWriteCloser) Close() error {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/panicing_test/mock_test.go
+++ b/mockgen/internal/tests/panicing_test/mock_test.go
@@ -38,6 +38,11 @@ func (m *MockFoo) EXPECT() *MockFooMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockFoo) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Bar mocks base method.
 func (m *MockFoo) Bar() string {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/sanitization/mockout/mock.go
+++ b/mockgen/internal/tests/sanitization/mockout/mock.go
@@ -39,6 +39,11 @@ func (m *MockAnyMock) EXPECT() *MockAnyMockMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockAnyMock) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Do mocks base method.
 func (m *MockAnyMock) Do(arg0 *any0.Any, arg1 int) {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/self_package/mock.go
+++ b/mockgen/internal/tests/self_package/mock.go
@@ -38,6 +38,11 @@ func (m *MockMethods) EXPECT() *MockMethodsMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockMethods) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // getInfo mocks base method.
 func (m *MockMethods) getInfo() Info {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/test_package/mock_test.go
+++ b/mockgen/internal/tests/test_package/mock_test.go
@@ -38,6 +38,11 @@ func (m *MockFinder) EXPECT() *MockFinderMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockFinder) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Add mocks base method.
 func (m *MockFinder) Add(u User) {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/typed_inorder/mock.go
+++ b/mockgen/internal/tests/typed_inorder/mock.go
@@ -38,6 +38,11 @@ func (m *MockAnimal) EXPECT() *MockAnimalMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockAnimal) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Feed mocks base method.
 func (m *MockAnimal) Feed(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/unexported_method/bugreport_mock.go
+++ b/mockgen/internal/tests/unexported_method/bugreport_mock.go
@@ -38,6 +38,11 @@ func (m *MockExample) EXPECT() *MockExampleMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockExample) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // someMethod mocks base method.
 func (m *MockExample) someMethod(arg0 string) string {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/vendor_dep/mock.go
+++ b/mockgen/internal/tests/vendor_dep/mock.go
@@ -39,6 +39,11 @@ func (m *MockVendorsDep) EXPECT() *MockVendorsDepMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockVendorsDep) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Foo mocks base method.
 func (m *MockVendorsDep) Foo() present.Elem {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/vendor_dep/source_mock_package/mock.go
+++ b/mockgen/internal/tests/vendor_dep/source_mock_package/mock.go
@@ -39,6 +39,11 @@ func (m *MockVendorsDep) EXPECT() *MockVendorsDepMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockVendorsDep) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Foo mocks base method.
 func (m *MockVendorsDep) Foo() present.Elem {
 	m.ctrl.T.Helper()

--- a/mockgen/internal/tests/vendor_pkg/mock.go
+++ b/mockgen/internal/tests/vendor_pkg/mock.go
@@ -38,6 +38,11 @@ func (m *MockElem) EXPECT() *MockElemMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockElem) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // TemplateName mocks base method.
 func (m *MockElem) TemplateName() string {
 	m.ctrl.T.Helper()

--- a/sample/concurrent/mock/concurrent_mock.go
+++ b/sample/concurrent/mock/concurrent_mock.go
@@ -38,6 +38,11 @@ func (m *MockMath) EXPECT() *MockMathMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockMath) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Sum mocks base method.
 func (m *MockMath) Sum(arg0, arg1 int) int {
 	m.ctrl.T.Helper()

--- a/sample/mock_user_test.go
+++ b/sample/mock_user_test.go
@@ -49,6 +49,11 @@ func (m *MockIndex) EXPECT() *MockIndexMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockIndex) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // Anon mocks base method.
 func (m *MockIndex) Anon(arg0 string) {
 	m.ctrl.T.Helper()
@@ -358,6 +363,11 @@ func (m *MockEmbed) EXPECT() *MockEmbedMockRecorder {
 	return m.recorder
 }
 
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockEmbed) ISGOMOCK() struct{} {
+	return struct{}{}
+}
+
 // EmbeddedMethod mocks base method.
 func (m *MockEmbed) EmbeddedMethod() {
 	m.ctrl.T.Helper()
@@ -429,6 +439,11 @@ func NewMockEmbedded(ctrl *gomock.Controller) *MockEmbedded {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEmbedded) EXPECT() *MockEmbeddedMockRecorder {
 	return m.recorder
+}
+
+// ISGOMOCK indicates that this struct is a gomock mock.
+func (m *MockEmbedded) ISGOMOCK() struct{} {
+	return struct{}{}
 }
 
 // EmbeddedMethod mocks base method.


### PR DESCRIPTION
related https://github.com/uber-go/mock/pull/144
Whether or not it is a good idea to generate an ISGOMOCK method for fmt.Stringer deadlock
