### PR TITLE
Support Go 1.22 and Go 1.23

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.22.x
+        go-version: 1.23.x
 
     - name: Prepare release
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.21.x, 1.22.x] # oldest version that can build go mock and official supported go versions
+        go-version: [1.22.x, 1.23.x] # oldest version that can build go mock and official supported go versions
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/mock
 
-go 1.19
+go 1.22
 
 require (
 	golang.org/x/mod v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -3,5 +3,6 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
 golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
 golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=

--- a/mockgen/internal/tests/generics/go.mod
+++ b/mockgen/internal/tests/generics/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/mock/mockgen/internal/tests/generics
 
-go 1.19
+go 1.22
 
 replace go.uber.org/mock => ../../../..
 

--- a/mockgen/internal/tests/typed/go.mod
+++ b/mockgen/internal/tests/typed/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/mock/mockgen/internal/tests/typed
 
-go 1.19
+go 1.22
 
 replace go.uber.org/mock => ../../../..
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/uber-go/mock/tools
 
-go 1.19
+go 1.22
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
This change updates all `go.mod` and ci workflows to only support go1.22 and go1.23.

Although this will force users to upgrade to go1.22 to use the next release, it is technically in line with our release policy (see: https://github.com/uber-go/mock?tab=readme-ov-file#supported-go-versions) and will allow us to merge #198 without using build tags for references to the new `*types.Alias` and `types.Unalias()`.