### PR TITLE
Avoid stringer-related deadlocks without adding ISGOMOCK

### DIFF
--- a/gomock/internal/mock_gomock/mock_matcher.go
+++ b/gomock/internal/mock_gomock/mock_matcher.go
@@ -19,6 +19,7 @@ import (
 type MockMatcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockMatcherMockRecorder
+	isgomock struct{}
 }
 
 // MockMatcherMockRecorder is the mock recorder for MockMatcher.
@@ -36,11 +37,6 @@ func NewMockMatcher(ctrl *gomock.Controller) *MockMatcher {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMatcher) EXPECT() *MockMatcherMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockMatcher) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Matches mocks base method.

--- a/gomock/mock_test.go
+++ b/gomock/mock_test.go
@@ -19,6 +19,7 @@ import (
 type MockFoo struct {
 	ctrl     *gomock.Controller
 	recorder *MockFooMockRecorder
+	isgomock struct{}
 }
 
 // MockFooMockRecorder is the mock recorder for MockFoo.
@@ -36,11 +37,6 @@ func NewMockFoo(ctrl *gomock.Controller) *MockFoo {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFoo) EXPECT() *MockFooMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockFoo) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Bar mocks base method.

--- a/gomock/string.go
+++ b/gomock/string.go
@@ -1,25 +1,36 @@
 package gomock
 
-import "fmt"
-
-type mockInstance interface {
-	ISGOMOCK() struct{}
-}
-type mockedStringer interface {
-	fmt.Stringer
-	mockInstance
-}
+import (
+	"fmt"
+	"reflect"
+)
 
 // getString is a safe way to convert a value to a string for printing results
 // If the value is a a mock, getString avoids calling the mocked String() method,
 // which avoids potential deadlocks
 func getString(x any) string {
-	switch v := x.(type) {
-	case mockedStringer:
-		return fmt.Sprintf("%T", v)
-	case fmt.Stringer:
-		return v.String()
-	default:
-		return fmt.Sprintf("%v", v)
+	if isGeneratedMock(x) {
+		return fmt.Sprintf("%T", x)
 	}
+	if s, ok := x.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return fmt.Sprintf("%v", x)
+}
+
+// isGeneratedMock checks if the given type has a "isgomock" field,
+// indicating it is a generated mock.
+func isGeneratedMock(x any) bool {
+	typ := reflect.TypeOf(x)
+	if typ == nil {
+		return false
+	}
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct {
+		return false
+	}
+	_, isgomock := typ.FieldByName("isgomock")
+	return isgomock
 }

--- a/mockgen/internal/tests/add_generate_directive/mock.go
+++ b/mockgen/internal/tests/add_generate_directive/mock.go
@@ -21,6 +21,7 @@ import (
 type MockFoo struct {
 	ctrl     *gomock.Controller
 	recorder *MockFooMockRecorder
+	isgomock struct{}
 }
 
 // MockFooMockRecorder is the mock recorder for MockFoo.
@@ -38,11 +39,6 @@ func NewMockFoo(ctrl *gomock.Controller) *MockFoo {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFoo) EXPECT() *MockFooMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockFoo) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Bar mocks base method.

--- a/mockgen/internal/tests/const_array_length/mock.go
+++ b/mockgen/internal/tests/const_array_length/mock.go
@@ -19,6 +19,7 @@ import (
 type MockI struct {
 	ctrl     *gomock.Controller
 	recorder *MockIMockRecorder
+	isgomock struct{}
 }
 
 // MockIMockRecorder is the mock recorder for MockI.
@@ -36,11 +37,6 @@ func NewMockI(ctrl *gomock.Controller) *MockI {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockI) EXPECT() *MockIMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockI) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Bar mocks base method.

--- a/mockgen/internal/tests/copyright_file/mock.go
+++ b/mockgen/internal/tests/copyright_file/mock.go
@@ -24,6 +24,7 @@ import (
 type MockEmpty struct {
 	ctrl     *gomock.Controller
 	recorder *MockEmptyMockRecorder
+	isgomock struct{}
 }
 
 // MockEmptyMockRecorder is the mock recorder for MockEmpty.
@@ -41,9 +42,4 @@ func NewMockEmpty(ctrl *gomock.Controller) *MockEmpty {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEmpty) EXPECT() *MockEmptyMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockEmpty) ISGOMOCK() struct{} {
-	return struct{}{}
 }

--- a/mockgen/internal/tests/custom_package_name/greeter/greeter_mock_test.go
+++ b/mockgen/internal/tests/custom_package_name/greeter/greeter_mock_test.go
@@ -20,6 +20,7 @@ import (
 type MockInputMaker struct {
 	ctrl     *gomock.Controller
 	recorder *MockInputMakerMockRecorder
+	isgomock struct{}
 }
 
 // MockInputMakerMockRecorder is the mock recorder for MockInputMaker.
@@ -37,11 +38,6 @@ func NewMockInputMaker(ctrl *gomock.Controller) *MockInputMaker {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInputMaker) EXPECT() *MockInputMakerMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockInputMaker) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // MakeInput mocks base method.

--- a/mockgen/internal/tests/defined_import_local_name/mock.go
+++ b/mockgen/internal/tests/defined_import_local_name/mock.go
@@ -21,6 +21,7 @@ import (
 type MockWithImports struct {
 	ctrl     *gomock.Controller
 	recorder *MockWithImportsMockRecorder
+	isgomock struct{}
 }
 
 // MockWithImportsMockRecorder is the mock recorder for MockWithImports.
@@ -38,11 +39,6 @@ func NewMockWithImports(ctrl *gomock.Controller) *MockWithImports {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockWithImports) EXPECT() *MockWithImportsMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockWithImports) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Method1 mocks base method.

--- a/mockgen/internal/tests/dot_imports/mock.go
+++ b/mockgen/internal/tests/dot_imports/mock.go
@@ -22,6 +22,7 @@ import (
 type MockWithDotImports struct {
 	ctrl     *gomock.Controller
 	recorder *MockWithDotImportsMockRecorder
+	isgomock struct{}
 }
 
 // MockWithDotImportsMockRecorder is the mock recorder for MockWithDotImports.
@@ -39,11 +40,6 @@ func NewMockWithDotImports(ctrl *gomock.Controller) *MockWithDotImports {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockWithDotImports) EXPECT() *MockWithDotImportsMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockWithDotImports) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Method1 mocks base method.

--- a/mockgen/internal/tests/empty_interface/mock.go
+++ b/mockgen/internal/tests/empty_interface/mock.go
@@ -17,6 +17,7 @@ import (
 type MockEmpty struct {
 	ctrl     *gomock.Controller
 	recorder *MockEmptyMockRecorder
+	isgomock struct{}
 }
 
 // MockEmptyMockRecorder is the mock recorder for MockEmpty.
@@ -34,9 +35,4 @@ func NewMockEmpty(ctrl *gomock.Controller) *MockEmpty {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEmpty) EXPECT() *MockEmptyMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockEmpty) ISGOMOCK() struct{} {
-	return struct{}{}
 }

--- a/mockgen/internal/tests/exclude/mock.go
+++ b/mockgen/internal/tests/exclude/mock.go
@@ -19,6 +19,7 @@ import (
 type MockGenerateMockForMe struct {
 	ctrl     *gomock.Controller
 	recorder *MockGenerateMockForMeMockRecorder
+	isgomock struct{}
 }
 
 // MockGenerateMockForMeMockRecorder is the mock recorder for MockGenerateMockForMe.
@@ -36,11 +37,6 @@ func NewMockGenerateMockForMe(ctrl *gomock.Controller) *MockGenerateMockForMe {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGenerateMockForMe) EXPECT() *MockGenerateMockForMeMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockGenerateMockForMe) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // B mocks base method.

--- a/mockgen/internal/tests/extra_import/mock.go
+++ b/mockgen/internal/tests/extra_import/mock.go
@@ -19,6 +19,7 @@ import (
 type MockFoo struct {
 	ctrl     *gomock.Controller
 	recorder *MockFooMockRecorder
+	isgomock struct{}
 }
 
 // MockFooMockRecorder is the mock recorder for MockFoo.
@@ -36,11 +37,6 @@ func NewMockFoo(ctrl *gomock.Controller) *MockFoo {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFoo) EXPECT() *MockFooMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockFoo) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Bar mocks base method.

--- a/mockgen/internal/tests/generated_identifier_conflict/bugreport_mock.go
+++ b/mockgen/internal/tests/generated_identifier_conflict/bugreport_mock.go
@@ -19,6 +19,7 @@ import (
 type MockExample struct {
 	ctrl     *gomock.Controller
 	recorder *MockExampleMockRecorder
+	isgomock struct{}
 }
 
 // MockExampleMockRecorder is the mock recorder for MockExample.
@@ -36,11 +37,6 @@ func NewMockExample(ctrl *gomock.Controller) *MockExample {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExample) EXPECT() *MockExampleMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockExample) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Method mocks base method.

--- a/mockgen/internal/tests/generics/source/mock_external_mock.go
+++ b/mockgen/internal/tests/generics/source/mock_external_mock.go
@@ -23,6 +23,7 @@ import (
 type MockExternalConstraint[I constraints.Integer, F any] struct {
 	ctrl     *gomock.Controller
 	recorder *MockExternalConstraintMockRecorder[I, F]
+	isgomock struct{}
 }
 
 // MockExternalConstraintMockRecorder is the mock recorder for MockExternalConstraint.
@@ -40,11 +41,6 @@ func NewMockExternalConstraint[I constraints.Integer, F any](ctrl *gomock.Contro
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExternalConstraint[I, F]) EXPECT() *MockExternalConstraintMockRecorder[I, F] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockExternalConstraint[I, F]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Eight mocks base method.
@@ -233,6 +229,7 @@ func (mr *MockExternalConstraintMockRecorder[I, F]) Two(arg0 any) *gomock.Call {
 type MockEmbeddingIface[T constraints.Integer, R constraints.Float] struct {
 	ctrl     *gomock.Controller
 	recorder *MockEmbeddingIfaceMockRecorder[T, R]
+	isgomock struct{}
 }
 
 // MockEmbeddingIfaceMockRecorder is the mock recorder for MockEmbeddingIface.
@@ -250,11 +247,6 @@ func NewMockEmbeddingIface[T constraints.Integer, R constraints.Float](ctrl *gom
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEmbeddingIface[T, R]) EXPECT() *MockEmbeddingIfaceMockRecorder[T, R] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockEmbeddingIface[T, R]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Eight mocks base method.
@@ -542,6 +534,7 @@ func (mr *MockEmbeddingIfaceMockRecorder[T, R]) Water(arg0 any) *gomock.Call {
 type MockGenerator[T any] struct {
 	ctrl     *gomock.Controller
 	recorder *MockGeneratorMockRecorder[T]
+	isgomock struct{}
 }
 
 // MockGeneratorMockRecorder is the mock recorder for MockGenerator.
@@ -559,11 +552,6 @@ func NewMockGenerator[T any](ctrl *gomock.Controller) *MockGenerator[T] {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGenerator[T]) EXPECT() *MockGeneratorMockRecorder[T] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockGenerator[T]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Generate mocks base method.
@@ -584,6 +572,7 @@ func (mr *MockGeneratorMockRecorder[T]) Generate() *gomock.Call {
 type MockGroup[T generics.Generator[any]] struct {
 	ctrl     *gomock.Controller
 	recorder *MockGroupMockRecorder[T]
+	isgomock struct{}
 }
 
 // MockGroupMockRecorder is the mock recorder for MockGroup.
@@ -601,11 +590,6 @@ func NewMockGroup[T generics.Generator[any]](ctrl *gomock.Controller) *MockGroup
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGroup[T]) EXPECT() *MockGroupMockRecorder[T] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockGroup[T]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Join mocks base method.

--- a/mockgen/internal/tests/generics/source/mock_generics_mock.go
+++ b/mockgen/internal/tests/generics/source/mock_generics_mock.go
@@ -22,6 +22,7 @@ import (
 type MockBar[T any, R any] struct {
 	ctrl     *gomock.Controller
 	recorder *MockBarMockRecorder[T, R]
+	isgomock struct{}
 }
 
 // MockBarMockRecorder is the mock recorder for MockBar.
@@ -39,11 +40,6 @@ func NewMockBar[T any, R any](ctrl *gomock.Controller) *MockBar[T, R] {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBar[T, R]) EXPECT() *MockBarMockRecorder[T, R] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockBar[T, R]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Eight mocks base method.
@@ -320,6 +316,7 @@ func (mr *MockBarMockRecorder[T, R]) Two(arg0 any) *gomock.Call {
 type MockUniverse[T constraints.Signed] struct {
 	ctrl     *gomock.Controller
 	recorder *MockUniverseMockRecorder[T]
+	isgomock struct{}
 }
 
 // MockUniverseMockRecorder is the mock recorder for MockUniverse.
@@ -337,11 +334,6 @@ func NewMockUniverse[T constraints.Signed](ctrl *gomock.Controller) *MockUnivers
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockUniverse[T]) EXPECT() *MockUniverseMockRecorder[T] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockUniverse[T]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Water mocks base method.
@@ -362,6 +354,7 @@ func (mr *MockUniverseMockRecorder[T]) Water(arg0 any) *gomock.Call {
 type MockMilkyWay[R constraints.Integer] struct {
 	ctrl     *gomock.Controller
 	recorder *MockMilkyWayMockRecorder[R]
+	isgomock struct{}
 }
 
 // MockMilkyWayMockRecorder is the mock recorder for MockMilkyWay.
@@ -379,11 +372,6 @@ func NewMockMilkyWay[R constraints.Integer](ctrl *gomock.Controller) *MockMilkyW
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMilkyWay[R]) EXPECT() *MockMilkyWayMockRecorder[R] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockMilkyWay[R]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Water mocks base method.
@@ -404,6 +392,7 @@ func (mr *MockMilkyWayMockRecorder[R]) Water(arg0 any) *gomock.Call {
 type MockSolarSystem[T constraints.Ordered] struct {
 	ctrl     *gomock.Controller
 	recorder *MockSolarSystemMockRecorder[T]
+	isgomock struct{}
 }
 
 // MockSolarSystemMockRecorder is the mock recorder for MockSolarSystem.
@@ -421,11 +410,6 @@ func NewMockSolarSystem[T constraints.Ordered](ctrl *gomock.Controller) *MockSol
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSolarSystem[T]) EXPECT() *MockSolarSystemMockRecorder[T] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockSolarSystem[T]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Water mocks base method.
@@ -446,6 +430,7 @@ func (mr *MockSolarSystemMockRecorder[T]) Water(arg0 any) *gomock.Call {
 type MockEarth[R any] struct {
 	ctrl     *gomock.Controller
 	recorder *MockEarthMockRecorder[R]
+	isgomock struct{}
 }
 
 // MockEarthMockRecorder is the mock recorder for MockEarth.
@@ -463,11 +448,6 @@ func NewMockEarth[R any](ctrl *gomock.Controller) *MockEarth[R] {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEarth[R]) EXPECT() *MockEarthMockRecorder[R] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockEarth[R]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Water mocks base method.
@@ -488,6 +468,7 @@ func (mr *MockEarthMockRecorder[R]) Water(arg0 any) *gomock.Call {
 type MockWater[R any, C generics.UnsignedInteger] struct {
 	ctrl     *gomock.Controller
 	recorder *MockWaterMockRecorder[R, C]
+	isgomock struct{}
 }
 
 // MockWaterMockRecorder is the mock recorder for MockWater.
@@ -505,11 +486,6 @@ func NewMockWater[R any, C generics.UnsignedInteger](ctrl *gomock.Controller) *M
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockWater[R, C]) EXPECT() *MockWaterMockRecorder[R, C] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockWater[R, C]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Fish mocks base method.

--- a/mockgen/internal/tests/import_embedded_interface/bugreport_mock.go
+++ b/mockgen/internal/tests/import_embedded_interface/bugreport_mock.go
@@ -21,6 +21,7 @@ import (
 type MockSource struct {
 	ctrl     *gomock.Controller
 	recorder *MockSourceMockRecorder
+	isgomock struct{}
 }
 
 // MockSourceMockRecorder is the mock recorder for MockSource.
@@ -38,11 +39,6 @@ func NewMockSource(ctrl *gomock.Controller) *MockSource {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSource) EXPECT() *MockSourceMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockSource) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Bar mocks base method.

--- a/mockgen/internal/tests/import_embedded_interface/net_mock.go
+++ b/mockgen/internal/tests/import_embedded_interface/net_mock.go
@@ -20,6 +20,7 @@ import (
 type MockNet struct {
 	ctrl     *gomock.Controller
 	recorder *MockNetMockRecorder
+	isgomock struct{}
 }
 
 // MockNetMockRecorder is the mock recorder for MockNet.
@@ -37,11 +38,6 @@ func NewMockNet(ctrl *gomock.Controller) *MockNet {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNet) EXPECT() *MockNetMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockNet) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Header mocks base method.

--- a/mockgen/internal/tests/import_source/definition/source_mock.go
+++ b/mockgen/internal/tests/import_source/definition/source_mock.go
@@ -19,6 +19,7 @@ import (
 type MockS struct {
 	ctrl     *gomock.Controller
 	recorder *MockSMockRecorder
+	isgomock struct{}
 }
 
 // MockSMockRecorder is the mock recorder for MockS.
@@ -36,11 +37,6 @@ func NewMockS(ctrl *gomock.Controller) *MockS {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockS) EXPECT() *MockSMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockS) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // F mocks base method.

--- a/mockgen/internal/tests/import_source/source_mock.go
+++ b/mockgen/internal/tests/import_source/source_mock.go
@@ -20,6 +20,7 @@ import (
 type MockS struct {
 	ctrl     *gomock.Controller
 	recorder *MockSMockRecorder
+	isgomock struct{}
 }
 
 // MockSMockRecorder is the mock recorder for MockS.
@@ -37,11 +38,6 @@ func NewMockS(ctrl *gomock.Controller) *MockS {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockS) EXPECT() *MockSMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockS) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // F mocks base method.

--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/mock.go
+++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/mock.go
@@ -20,6 +20,7 @@ import (
 type MockArg struct {
 	ctrl     *gomock.Controller
 	recorder *MockArgMockRecorder
+	isgomock struct{}
 }
 
 // MockArgMockRecorder is the mock recorder for MockArg.
@@ -37,11 +38,6 @@ func NewMockArg(ctrl *gomock.Controller) *MockArg {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockArg) EXPECT() *MockArgMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockArg) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Foo mocks base method.
@@ -62,6 +58,7 @@ func (mr *MockArgMockRecorder) Foo() *gomock.Call {
 type MockIntf struct {
 	ctrl     *gomock.Controller
 	recorder *MockIntfMockRecorder
+	isgomock struct{}
 }
 
 // MockIntfMockRecorder is the mock recorder for MockIntf.
@@ -79,11 +76,6 @@ func NewMockIntf(ctrl *gomock.Controller) *MockIntf {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIntf) EXPECT() *MockIntfMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockIntf) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // F mocks base method.

--- a/mockgen/internal/tests/missing_import/output/source_mock.go
+++ b/mockgen/internal/tests/missing_import/output/source_mock.go
@@ -20,6 +20,7 @@ import (
 type MockBar struct {
 	ctrl     *gomock.Controller
 	recorder *MockBarMockRecorder
+	isgomock struct{}
 }
 
 // MockBarMockRecorder is the mock recorder for MockBar.
@@ -37,11 +38,6 @@ func NewMockBar(ctrl *gomock.Controller) *MockBar {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBar) EXPECT() *MockBarMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockBar) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Baz mocks base method.

--- a/mockgen/internal/tests/mock_in_test_package/mock_test.go
+++ b/mockgen/internal/tests/mock_in_test_package/mock_test.go
@@ -20,6 +20,7 @@ import (
 type MockFinder struct {
 	ctrl     *gomock.Controller
 	recorder *MockFinderMockRecorder
+	isgomock struct{}
 }
 
 // MockFinderMockRecorder is the mock recorder for MockFinder.
@@ -37,11 +38,6 @@ func NewMockFinder(ctrl *gomock.Controller) *MockFinder {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFinder) EXPECT() *MockFinderMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockFinder) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Add mocks base method.

--- a/mockgen/internal/tests/mock_name/mocks/post_service.go
+++ b/mockgen/internal/tests/mock_name/mocks/post_service.go
@@ -21,6 +21,7 @@ import (
 type PostServiceMock struct {
 	ctrl     *gomock.Controller
 	recorder *PostServiceMockMockRecorder
+	isgomock struct{}
 }
 
 // PostServiceMockMockRecorder is the mock recorder for PostServiceMock.
@@ -38,11 +39,6 @@ func NewPostServiceMock(ctrl *gomock.Controller) *PostServiceMock {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *PostServiceMock) EXPECT() *PostServiceMockMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *PostServiceMock) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Create mocks base method.

--- a/mockgen/internal/tests/mock_name/mocks/user_service.go
+++ b/mockgen/internal/tests/mock_name/mocks/user_service.go
@@ -20,6 +20,7 @@ import (
 type UserServiceMock struct {
 	ctrl     *gomock.Controller
 	recorder *UserServiceMockMockRecorder
+	isgomock struct{}
 }
 
 // UserServiceMockMockRecorder is the mock recorder for UserServiceMock.
@@ -37,11 +38,6 @@ func NewUserServiceMock(ctrl *gomock.Controller) *UserServiceMock {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *UserServiceMock) EXPECT() *UserServiceMockMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *UserServiceMock) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Create mocks base method.

--- a/mockgen/internal/tests/overlapping_methods/mock.go
+++ b/mockgen/internal/tests/overlapping_methods/mock.go
@@ -19,6 +19,7 @@ import (
 type MockReadWriteCloser struct {
 	ctrl     *gomock.Controller
 	recorder *MockReadWriteCloserMockRecorder
+	isgomock struct{}
 }
 
 // MockReadWriteCloserMockRecorder is the mock recorder for MockReadWriteCloser.
@@ -36,11 +37,6 @@ func NewMockReadWriteCloser(ctrl *gomock.Controller) *MockReadWriteCloser {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockReadWriteCloser) EXPECT() *MockReadWriteCloserMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockReadWriteCloser) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Close mocks base method.

--- a/mockgen/internal/tests/package_comment/mock.go
+++ b/mockgen/internal/tests/package_comment/mock.go
@@ -16,6 +16,7 @@ import (
 type MockEmpty struct {
 	ctrl     *gomock.Controller
 	recorder *MockEmptyMockRecorder
+	isgomock struct{}
 }
 
 // MockEmptyMockRecorder is the mock recorder for MockEmpty.
@@ -33,9 +34,4 @@ func NewMockEmpty(ctrl *gomock.Controller) *MockEmpty {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEmpty) EXPECT() *MockEmptyMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockEmpty) ISGOMOCK() struct{} {
-	return struct{}{}
 }

--- a/mockgen/internal/tests/panicing_test/mock_test.go
+++ b/mockgen/internal/tests/panicing_test/mock_test.go
@@ -19,6 +19,7 @@ import (
 type MockFoo struct {
 	ctrl     *gomock.Controller
 	recorder *MockFooMockRecorder
+	isgomock struct{}
 }
 
 // MockFooMockRecorder is the mock recorder for MockFoo.
@@ -36,11 +37,6 @@ func NewMockFoo(ctrl *gomock.Controller) *MockFoo {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFoo) EXPECT() *MockFooMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockFoo) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Bar mocks base method.

--- a/mockgen/internal/tests/sanitization/mockout/mock.go
+++ b/mockgen/internal/tests/sanitization/mockout/mock.go
@@ -20,6 +20,7 @@ import (
 type MockAnyMock struct {
 	ctrl     *gomock.Controller
 	recorder *MockAnyMockMockRecorder
+	isgomock struct{}
 }
 
 // MockAnyMockMockRecorder is the mock recorder for MockAnyMock.
@@ -37,11 +38,6 @@ func NewMockAnyMock(ctrl *gomock.Controller) *MockAnyMock {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAnyMock) EXPECT() *MockAnyMockMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockAnyMock) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Do mocks base method.

--- a/mockgen/internal/tests/self_package/mock.go
+++ b/mockgen/internal/tests/self_package/mock.go
@@ -19,6 +19,7 @@ import (
 type MockMethods struct {
 	ctrl     *gomock.Controller
 	recorder *MockMethodsMockRecorder
+	isgomock struct{}
 }
 
 // MockMethodsMockRecorder is the mock recorder for MockMethods.
@@ -36,11 +37,6 @@ func NewMockMethods(ctrl *gomock.Controller) *MockMethods {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMethods) EXPECT() *MockMethodsMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockMethods) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // getInfo mocks base method.

--- a/mockgen/internal/tests/test_package/mock_test.go
+++ b/mockgen/internal/tests/test_package/mock_test.go
@@ -19,6 +19,7 @@ import (
 type MockFinder struct {
 	ctrl     *gomock.Controller
 	recorder *MockFinderMockRecorder
+	isgomock struct{}
 }
 
 // MockFinderMockRecorder is the mock recorder for MockFinder.
@@ -36,11 +37,6 @@ func NewMockFinder(ctrl *gomock.Controller) *MockFinder {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFinder) EXPECT() *MockFinderMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockFinder) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Add mocks base method.

--- a/mockgen/internal/tests/typed/bugreport_mock.go
+++ b/mockgen/internal/tests/typed/bugreport_mock.go
@@ -20,6 +20,7 @@ import (
 type MockSource struct {
 	ctrl     *gomock.Controller
 	recorder *MockSourceMockRecorder
+	isgomock struct{}
 }
 
 // MockSourceMockRecorder is the mock recorder for MockSource.
@@ -37,11 +38,6 @@ func NewMockSource(ctrl *gomock.Controller) *MockSource {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSource) EXPECT() *MockSourceMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockSource) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Error mocks base method.

--- a/mockgen/internal/tests/typed/source/mock_external_test.go
+++ b/mockgen/internal/tests/typed/source/mock_external_test.go
@@ -22,6 +22,7 @@ import (
 type MockExternalConstraint[I constraints.Integer, F constraints.Float] struct {
 	ctrl     *gomock.Controller
 	recorder *MockExternalConstraintMockRecorder[I, F]
+	isgomock struct{}
 }
 
 // MockExternalConstraintMockRecorder is the mock recorder for MockExternalConstraint.
@@ -39,11 +40,6 @@ func NewMockExternalConstraint[I constraints.Integer, F constraints.Float](ctrl 
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExternalConstraint[I, F]) EXPECT() *MockExternalConstraintMockRecorder[I, F] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockExternalConstraint[I, F]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Eight mocks base method.

--- a/mockgen/internal/tests/typed/source/mock_generics_test.go
+++ b/mockgen/internal/tests/typed/source/mock_generics_test.go
@@ -21,6 +21,7 @@ import (
 type MockBar[T any, R any] struct {
 	ctrl     *gomock.Controller
 	recorder *MockBarMockRecorder[T, R]
+	isgomock struct{}
 }
 
 // MockBarMockRecorder is the mock recorder for MockBar.
@@ -38,11 +39,6 @@ func NewMockBar[T any, R any](ctrl *gomock.Controller) *MockBar[T, R] {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBar[T, R]) EXPECT() *MockBarMockRecorder[T, R] {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockBar[T, R]) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Eight mocks base method.

--- a/mockgen/internal/tests/typed_inorder/mock.go
+++ b/mockgen/internal/tests/typed_inorder/mock.go
@@ -19,6 +19,7 @@ import (
 type MockAnimal struct {
 	ctrl     *gomock.Controller
 	recorder *MockAnimalMockRecorder
+	isgomock struct{}
 }
 
 // MockAnimalMockRecorder is the mock recorder for MockAnimal.
@@ -36,11 +37,6 @@ func NewMockAnimal(ctrl *gomock.Controller) *MockAnimal {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAnimal) EXPECT() *MockAnimalMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockAnimal) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Feed mocks base method.

--- a/mockgen/internal/tests/unexported_method/bugreport_mock.go
+++ b/mockgen/internal/tests/unexported_method/bugreport_mock.go
@@ -19,6 +19,7 @@ import (
 type MockExample struct {
 	ctrl     *gomock.Controller
 	recorder *MockExampleMockRecorder
+	isgomock struct{}
 }
 
 // MockExampleMockRecorder is the mock recorder for MockExample.
@@ -36,11 +37,6 @@ func NewMockExample(ctrl *gomock.Controller) *MockExample {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExample) EXPECT() *MockExampleMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockExample) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // someMethod mocks base method.

--- a/mockgen/internal/tests/vendor_dep/mock.go
+++ b/mockgen/internal/tests/vendor_dep/mock.go
@@ -20,6 +20,7 @@ import (
 type MockVendorsDep struct {
 	ctrl     *gomock.Controller
 	recorder *MockVendorsDepMockRecorder
+	isgomock struct{}
 }
 
 // MockVendorsDepMockRecorder is the mock recorder for MockVendorsDep.
@@ -37,11 +38,6 @@ func NewMockVendorsDep(ctrl *gomock.Controller) *MockVendorsDep {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockVendorsDep) EXPECT() *MockVendorsDepMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockVendorsDep) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Foo mocks base method.

--- a/mockgen/internal/tests/vendor_dep/source_mock_package/mock.go
+++ b/mockgen/internal/tests/vendor_dep/source_mock_package/mock.go
@@ -20,6 +20,7 @@ import (
 type MockVendorsDep struct {
 	ctrl     *gomock.Controller
 	recorder *MockVendorsDepMockRecorder
+	isgomock struct{}
 }
 
 // MockVendorsDepMockRecorder is the mock recorder for MockVendorsDep.
@@ -37,11 +38,6 @@ func NewMockVendorsDep(ctrl *gomock.Controller) *MockVendorsDep {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockVendorsDep) EXPECT() *MockVendorsDepMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockVendorsDep) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Foo mocks base method.

--- a/mockgen/internal/tests/vendor_pkg/mock.go
+++ b/mockgen/internal/tests/vendor_pkg/mock.go
@@ -19,6 +19,7 @@ import (
 type MockElem struct {
 	ctrl     *gomock.Controller
 	recorder *MockElemMockRecorder
+	isgomock struct{}
 }
 
 // MockElemMockRecorder is the mock recorder for MockElem.
@@ -36,11 +37,6 @@ func NewMockElem(ctrl *gomock.Controller) *MockElem {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockElem) EXPECT() *MockElemMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockElem) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // TemplateName mocks base method.

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -477,6 +477,7 @@ func (g *generator) GenerateMockInterface(intf *model.Interface, outputPackagePa
 	g.in()
 	g.p("ctrl     *gomock.Controller")
 	g.p("recorder *%vMockRecorder%v", mockType, shortTp)
+	g.p("isgomock struct{}")
 	g.out()
 	g.p("}")
 	g.p("")
@@ -504,14 +505,6 @@ func (g *generator) GenerateMockInterface(intf *model.Interface, outputPackagePa
 	g.p("func (m *%v%v) EXPECT() *%vMockRecorder%v {", mockType, shortTp, mockType, shortTp)
 	g.in()
 	g.p("return m.recorder")
-	g.out()
-	g.p("}")
-
-	// XXX: possible name collision here if someone has ISGOMOCK in their interface.
-	g.p("// ISGOMOCK indicates that this struct is a gomock mock.")
-	g.p("func (m *%v%v) ISGOMOCK() struct{} {", mockType, shortTp)
-	g.in()
-	g.p("return struct{}{}")
 	g.out()
 	g.p("}")
 

--- a/sample/concurrent/mock/concurrent_mock.go
+++ b/sample/concurrent/mock/concurrent_mock.go
@@ -19,6 +19,7 @@ import (
 type MockMath struct {
 	ctrl     *gomock.Controller
 	recorder *MockMathMockRecorder
+	isgomock struct{}
 }
 
 // MockMathMockRecorder is the mock recorder for MockMath.
@@ -36,11 +37,6 @@ func NewMockMath(ctrl *gomock.Controller) *MockMath {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMath) EXPECT() *MockMathMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockMath) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Sum mocks base method.

--- a/sample/mock_user_test.go
+++ b/sample/mock_user_test.go
@@ -30,6 +30,7 @@ import (
 type MockIndex struct {
 	ctrl     *gomock.Controller
 	recorder *MockIndexMockRecorder
+	isgomock struct{}
 }
 
 // MockIndexMockRecorder is the mock recorder for MockIndex.
@@ -47,11 +48,6 @@ func NewMockIndex(ctrl *gomock.Controller) *MockIndex {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIndex) EXPECT() *MockIndexMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockIndex) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // Anon mocks base method.
@@ -344,6 +340,7 @@ func (mr *MockIndexMockRecorder) Templates(arg0, arg1 any) *gomock.Call {
 type MockEmbed struct {
 	ctrl     *gomock.Controller
 	recorder *MockEmbedMockRecorder
+	isgomock struct{}
 }
 
 // MockEmbedMockRecorder is the mock recorder for MockEmbed.
@@ -361,11 +358,6 @@ func NewMockEmbed(ctrl *gomock.Controller) *MockEmbed {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEmbed) EXPECT() *MockEmbedMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockEmbed) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // EmbeddedMethod mocks base method.
@@ -422,6 +414,7 @@ func (mr *MockEmbedMockRecorder) RegularMethod() *gomock.Call {
 type MockEmbedded struct {
 	ctrl     *gomock.Controller
 	recorder *MockEmbeddedMockRecorder
+	isgomock struct{}
 }
 
 // MockEmbeddedMockRecorder is the mock recorder for MockEmbedded.
@@ -439,11 +432,6 @@ func NewMockEmbedded(ctrl *gomock.Controller) *MockEmbedded {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEmbedded) EXPECT() *MockEmbeddedMockRecorder {
 	return m.recorder
-}
-
-// ISGOMOCK indicates that this struct is a gomock mock.
-func (m *MockEmbedded) ISGOMOCK() struct{} {
-	return struct{}{}
 }
 
 // EmbeddedMethod mocks base method.


### PR DESCRIPTION
A deadlock related to controller calling Stringer on mocks themselves
was revealed in #116. #144 solved this deadlock by adding a generated
`ISGOMOCK()` method to all generated mocks, and then checking for it
before calling `.String()` on arguments.

This reveals an exported method on each generated mock that:
* Bloats the generated code
* Can be taken dependency on in strange ways via Hyrum's Law
* Technically opens up another route for naming collision.

This PR attempts to clean up this type of check by instead generating
an unexported field in generated mock structs instead, and checks for it using reflect.
This hides this implementation detail of gomock/mockgen better,
and produces less generated bloat.

Note that, importantly, the regression test added in #144 still passes
with this PR.

Ref: #193