### PR TITLE
Support optional diff formatter fn for eq

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,39 @@ Got: [0 1 1 2 3]
 Want: is equal to 1
 ```
 
+### Custom diff formatter for unequal args
+
+You can provide a custom diff formatter function to the Controller, which will
+be invoked instead of the default formatting when the `Eq` matcher fails.
+
+(`Eq` is the default matcher for expectations with arbitrary values).
+
+Other matchers are unaffected. (This includes `GotFormatter` implementations
+and matchers wrapped in `WantFormatter` documented below).
+
+```go
+myDiffer := func(expected, actual any) {
+  return fmt.Sprintf("My custom diff:\n- %v\n+ %v", expected, actual)
+  // or pass to another lib, like go-cmp cmp.Diff
+}
+
+ctrl := gomock.NewController(t, gomock.WithDiffFormatter(myDiffer))
+
+// ...
+
+mymock.EXPECT().Foo("my expected string")
+mymock.Foo("my actual string")
+```
+
+```
+Unexpected call to *mymocks.MyMock.Foo([my actual string]) at ... because: 
+expected call at ... doesn't match the argument at index 0.
+My custom diff:
+- my expected string
++ my actual string
+```
+
+
 ### Modifying `Want`
 
 The `Want` value comes from the matcher's `String()` method. If the matcher's

--- a/gomock/callset_test.go
+++ b/gomock/callset_test.go
@@ -30,7 +30,7 @@ func TestCallSetAdd(t *testing.T) {
 
 	numCalls := 10
 	for i := 0; i < numCalls; i++ {
-		cs.Add(newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func)))
+		cs.Add(newCall(t, nil, receiver, method, reflect.TypeOf(receiverType{}.Func)))
 	}
 
 	call, err := cs.FindMatch(receiver, method, []any{})
@@ -47,13 +47,13 @@ func TestCallSetAdd_WhenOverridable_ClearsPreviousExpectedAndExhausted(t *testin
 	var receiver any = "TestReceiver"
 	cs := newOverridableCallSet()
 
-	cs.Add(newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func)))
+	cs.Add(newCall(t, nil, receiver, method, reflect.TypeOf(receiverType{}.Func)))
 	numExpectedCalls := len(cs.expected[callSetKey{receiver, method}])
 	if numExpectedCalls != 1 {
 		t.Fatalf("Expected 1 expected call in callset, got %d", numExpectedCalls)
 	}
 
-	cs.Add(newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func)))
+	cs.Add(newCall(t, nil, receiver, method, reflect.TypeOf(receiverType{}.Func)))
 	newNumExpectedCalls := len(cs.expected[callSetKey{receiver, method}])
 	if newNumExpectedCalls != 1 {
 		t.Fatalf("Expected 1 expected call in callset, got %d", newNumExpectedCalls)
@@ -100,7 +100,7 @@ func TestCallSetFindMatch(t *testing.T) {
 		method := "TestMethod"
 		args := []any{}
 
-		c1 := newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func))
+		c1 := newCall(t, nil, receiver, method, reflect.TypeOf(receiverType{}.Func))
 		cs.exhausted = map[callSetKey][]*Call{
 			{receiver: receiver, fname: method}: {c1},
 		}


### PR DESCRIPTION
I'm keen to see progress on more useful output when expectations fail – e.g. #130 and various historical tickets on the original repo.

PR #154 proposes directly using go-cmp's `cmp.Diff` internally for this purpose. That would be great from my POV. But maintainers have given feedback about change scope and extra dependency.

So this is an alternative approach, which tries to assuage those concerns... or at least revive the conversation.

----

This implements a new Controller option,`WithDiffFormatter`. It takes a function that is called with the expected and actual values, only when the `Eq` matcher fails.  I think this would cover the vast majority of use-cases.

This gives users freedom to do what they like, including passing to `cmp.Diff` or a similar lib.

I think this is a significant improvement over the status quo:

- because true diff-style output, for deep/complex objects, isn't possible with the current `GotFormatter` and `WantFormatter`.
- because it avoids the need for _every_ expectation to be set up with custom formatting wrappers. 