### PR TITLE
Improve package mode performance

### DIFF
--- a/mockgen/package_mode.go
+++ b/mockgen/package_mode.go
@@ -147,7 +147,7 @@ func (p *packageModeParser) loadPackage(packageName string) (*packages.Package, 
 	}
 
 	cfg := &packages.Config{
-		Mode:       packages.NeedDeps | packages.NeedImports | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedEmbedFiles | packages.LoadSyntax,
+		Mode:       packages.LoadSyntax,
 		BuildFlags: buildFlagsSet,
 	}
 	pkgs, err := packages.Load(cfg, packageName)


### PR DESCRIPTION
Instead of loading the package and all its dependencies, load only the specified package, which significantly improves the performance in our case.