### PR TITLE
Copying gomock definition and tests from rules_go

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         os:
           - macos
-          - debian
+          - ubuntu
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  go:
     strategy:
       matrix:
         go-version: [1.22.x, 1.23.x] # oldest version that can build go mock and official supported go versions
@@ -40,10 +40,35 @@ jobs:
         ./ci/test.sh
         ./ci/check_panic_handling.sh
 
-    - name: Run Tests
+    - name: Run Go Tests
       run: |
-        for i in $(find $PWD -name go.mod); do
+        for i in $(find $PWD -name go.mod ! -path "$PWD/bazel/go.mod"); do
           pushd $(dirname $i)
           go test ./...
           popd
         done 
+
+  bazel:
+    strategy:
+      matrix:
+        os:
+          - macos
+          - debian
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.10.0
+        with:
+          # Avoid downloading Bazel every time.
+          bazelisk-cache: true
+          # Store build cache per workflow.
+          disk-cache: ${{ github.workflow }}
+          # Share repository cache between workflows.
+          repository-cache: true
+
+      - name: Run Bazel tests
+        run: |
+          cd bazel && bazel test //...

--- a/bazel/.gitignore
+++ b/bazel/.gitignore
@@ -1,0 +1,2 @@
+bazel-*
+MODULE.bazel.lock

--- a/bazel/MODULE.bazel
+++ b/bazel/MODULE.bazel
@@ -1,0 +1,16 @@
+module(name = "bazel_gomock")
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_go", version = "0.51.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.40.0")
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+
+go_sdk.download(version = "1.23.1")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "org_uber_go_mock",
+)

--- a/bazel/MODULE.bazel
+++ b/bazel/MODULE.bazel
@@ -6,7 +6,7 @@ bazel_dep(name = "gazelle", version = "0.40.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 
-go_sdk.download(version = "1.23.1")
+go_sdk.download(version = "1.23.4")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")

--- a/bazel/go.mod
+++ b/bazel/go.mod
@@ -1,0 +1,5 @@
+module go.uber.org/mock/bazel
+
+go 1.23.0
+
+require go.uber.org/mock v0.1.0

--- a/bazel/go.mod
+++ b/bazel/go.mod
@@ -2,4 +2,4 @@ module go.uber.org/mock/bazel
 
 go 1.23.0
 
-require go.uber.org/mock v0.1.0
+require go.uber.org/mock v0.4.0

--- a/bazel/go.sum
+++ b/bazel/go.sum
@@ -1,2 +1,2 @@
-go.uber.org/mock v0.1.0 h1:NEVjcPIj/L96qilPi+2M5l9zUkQksRaqNKphz3pStHI=
-go.uber.org/mock v0.1.0/go.mod h1:J0y0rp9L3xiff1+ZBfKxlC1fz2+aO16tw0tsDOixfuM=
+go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
+go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=

--- a/bazel/go.sum
+++ b/bazel/go.sum
@@ -1,0 +1,2 @@
+go.uber.org/mock v0.1.0 h1:NEVjcPIj/L96qilPi+2M5l9zUkQksRaqNKphz3pStHI=
+go.uber.org/mock v0.1.0/go.mod h1:J0y0rp9L3xiff1+ZBfKxlC1fz2+aO16tw0tsDOixfuM=

--- a/bazel/rules/BUILD.bazel
+++ b/bazel/rules/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "rules",
+    srcs = ["tools.go"],
+    importpath = "go.uber.org/mock/bazel/rules",
+    visibility = ["//visibility:public"],
+    deps = ["@org_uber_go_mock//mockgen/model:go_default_library"],
+)

--- a/bazel/rules/gomock.bzl
+++ b/bazel/rules/gomock.bzl
@@ -1,0 +1,428 @@
+# The MIT License (MIT)
+# Copyright © 2018 Jeff Hodges <jeff@somethingsimilar.com>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the “Software”), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# The rules in this files are still under development. Breaking changes are planned.
+# DO NOT USE IT.
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@io_bazel_rules_go//go/private:common.bzl", "GO_TOOLCHAIN", "GO_TOOLCHAIN_LABEL")
+load("@io_bazel_rules_go//go/private:context.bzl", "go_context")
+load("@io_bazel_rules_go//go/private:providers.bzl", "GoInfo")
+load("@io_bazel_rules_go//go/private/rules:wrappers.bzl", go_binary = "go_binary_macro")
+
+_MOCKGEN_TOOL = Label("@org_uber_go_mock//mockgen")
+_MOCKGEN_MODEL_LIB = Label("@org_uber_go_mock//mockgen/model")
+
+def _gomock_source_impl(ctx):
+    go = go_context(ctx, include_deprecated_properties = False)
+
+    # In Source mode, it's not necessary to pass through a library, as the only thing we use it for is setting up
+    # the relative file locations. Forcing users to pass a library makes it difficult in the case where a mock should
+    # be included as part of that same library, as it results in a dependency loop (GoMock -> GoInfo -> GoMock).
+    # Allowing users to pass an importpath directly bypasses this issue.
+    # See the test case in //tests/extras/gomock/source_with_importpath for an example.
+    importpath = ctx.attr.source_importpath if ctx.attr.source_importpath else ctx.attr.library[GoInfo].importmap
+
+    # create GOPATH and copy source into GOPATH
+    go_path_prefix = "gopath"
+    source_relative_path = paths.join("src", importpath, ctx.file.source.basename)
+    source = ctx.actions.declare_file(paths.join("gopath", source_relative_path))
+
+    # trim the relative path of source to get GOPATH
+    gopath = source.path[:-len(source_relative_path)]
+    ctx.actions.run_shell(
+        outputs = [source],
+        inputs = [ctx.file.source],
+        command = "mkdir -p {0} && cp -L {1} {0}".format(source.dirname, ctx.file.source.path),
+        mnemonic = "GoMockSourceCopyFile",
+    )
+
+    # passed in source needs to be in gopath to not trigger module mode
+    args = ["-source", source.path]
+
+    args, needed_files = _handle_shared_args(ctx, args)
+
+    if len(ctx.attr.aux_files) > 0:
+        aux_files = []
+        for target, pkg in ctx.attr.aux_files.items():
+            f = target.files.to_list()[0]
+            aux = ctx.actions.declare_file(paths.join(go_path_prefix, "src", pkg, f.basename))
+            ctx.actions.run_shell(
+                outputs = [aux],
+                inputs = [f],
+                command = "mkdir -p {0} && cp -L {1} {0}".format(aux.dirname, f.path),
+                mnemonic = "GoMockSourceCopyFile",
+            )
+            aux_files.append("{0}={1}".format(pkg, aux.path))
+            needed_files.append(aux)
+        args += ["-aux_files", ",".join(aux_files)]
+
+    sdk = go.sdk
+
+    inputs_direct = needed_files + [source]
+    inputs_transitive = [sdk.tools, sdk.headers, sdk.srcs]
+
+    # We can use the go binary from the stdlib for most of the environment
+    # variables, but our GOPATH is specific to the library target we were given.
+    ctx.actions.run_shell(
+        outputs = [ctx.outputs.out],
+        inputs = depset(inputs_direct, transitive = inputs_transitive),
+        tools = [
+            ctx.file.mockgen_tool,
+            sdk.go,
+        ],
+        toolchain = GO_TOOLCHAIN_LABEL,
+        command = """
+            export GOPATH=$(pwd)/{gopath} &&
+            export GOROOT=$(pwd)/{goroot} &&
+            export PATH=$GOROOT/bin:$PATH &&
+            {cmd} {args} > {out}
+        """.format(
+            gopath = gopath,
+            goroot = sdk.root_file.dirname,
+            cmd = "$(pwd)/" + ctx.file.mockgen_tool.path,
+            args = " ".join(args),
+            out = ctx.outputs.out.path,
+            mnemonic = "GoMockSourceGen",
+        ),
+        env = {
+            # GOCACHE is required starting in Go 1.12
+            "GOCACHE": "./.gocache",
+            # gomock runs in the special GOPATH environment
+            "GO111MODULE": "off",
+        },
+    )
+
+_gomock_source = rule(
+    _gomock_source_impl,
+    attrs = {
+        "library": attr.label(
+            doc = "The target the Go library where this source file belongs",
+            providers = [GoInfo],
+            mandatory = False,
+        ),
+        "source_importpath": attr.string(
+            doc = "The importpath for the source file. Alternative to passing library, which can lead to circular dependencies between mock and library targets.",
+            mandatory = False,
+        ),
+        "source": attr.label(
+            doc = "A Go source file to find all the interfaces to generate mocks for. See also the docs for library.",
+            mandatory = False,
+            allow_single_file = True,
+        ),
+        "out": attr.output(
+            doc = "The new Go file to emit the generated mocks into",
+            mandatory = True,
+        ),
+        "aux_files": attr.label_keyed_string_dict(
+            default = {},
+            doc = "A map from auxilliary Go source files to their packages.",
+            allow_files = True,
+        ),
+        "package": attr.string(
+            doc = "The name of the package the generated mocks should be in. If not specified, uses mockgen's default.",
+        ),
+        "self_package": attr.string(
+            doc = "The full package import path for the generated code. The purpose of this flag is to prevent import cycles in the generated code by trying to include its own package. This can happen if the mock's package is set to one of its inputs (usually the main one) and the output is stdio so mockgen cannot detect the final output package. Setting this flag will then tell mockgen which import to exclude.",
+        ),
+        "imports": attr.string_dict(
+            doc = "Dictionary of name-path pairs of explicit imports to use.",
+        ),
+        "mock_names": attr.string_dict(
+            doc = "Dictionary of interface name to mock name pairs to change the output names of the mock objects. Mock names default to 'Mock' prepended to the name of the interface.",
+            default = {},
+        ),
+        "copyright_file": attr.label(
+            doc = "Optional file containing copyright to prepend to the generated contents.",
+            allow_single_file = True,
+            mandatory = False,
+        ),
+        "mockgen_tool": attr.label(
+            doc = "The mockgen tool to run",
+            default = _MOCKGEN_TOOL,
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+            mandatory = False,
+        ),
+        "mockgen_args": attr.string_list(
+            doc = "Additional arguments to pass to the mockgen tool",
+            mandatory = False,
+        ),
+        "_go_context_data": attr.label(
+            default = "@io_bazel_rules_go//:go_context_data",
+        ),
+    },
+    toolchains = [GO_TOOLCHAIN],
+)
+
+def gomock(name, out, library = None, source_importpath = "", source = None, interfaces = [], package = "", self_package = "", aux_files = {}, mockgen_tool = _MOCKGEN_TOOL, mockgen_args = [], imports = {}, copyright_file = None, mock_names = {}, **kwargs):
+    """Calls [mockgen](https://github.com/golang/mock) to generates a Go file containing mocks from the given library.
+
+    If `source` is given, the mocks are generated in source mode; otherwise in reflective mode.
+
+    Args:
+        name: the target name.
+        out: the output Go file name.
+        library: the Go library to look into for the interfaces (reflective mode) or source (source mode). If running in source mode, you can specify source_importpath instead of this parameter.
+        source_importpath: the importpath for the source file. Alternative to passing library, which can lead to circular dependencies between mock and library targets. Only valid for source mode.
+        source: a Go file in the given `library`. If this is given, `gomock` will call mockgen in source mode to mock all interfaces in the file.
+        interfaces: a list of interfaces in the given `library` to be mocked in reflective mode.
+        package: the name of the package the generated mocks should be in. If not specified, uses mockgen's default. See [mockgen's -package](https://github.com/golang/mock#flags) for more information.
+        self_package: the full package import path for the generated code. The purpose of this flag is to prevent import cycles in the generated code by trying to include its own package. See [mockgen's -self_package](https://github.com/golang/mock#flags) for more information.
+        aux_files: a map from source files to their package path. This only needed when `source` is provided. See [mockgen's -aux_files](https://github.com/golang/mock#flags) for more information.
+        mockgen_tool: the mockgen tool to run.
+        mockgen_args: additional arguments to pass to the mockgen tool.
+        imports: dictionary of name-path pairs of explicit imports to use. See [mockgen's -imports](https://github.com/golang/mock#flags) for more information.
+        copyright_file: optional file containing copyright to prepend to the generated contents. See [mockgen's -copyright_file](https://github.com/golang/mock#flags) for more information.
+        mock_names: dictionary of interface name to mock name pairs to change the output names of the mock objects. Mock names default to 'Mock' prepended to the name of the interface. See [mockgen's -mock_names](https://github.com/golang/mock#flags) for more information.
+        kwargs: common attributes](https://bazel.build/reference/be/common-definitions#common-attributes) to all Bazel rules.
+    """
+    if source:
+        _gomock_source(
+            name = name,
+            out = out,
+            library = library,
+            source_importpath = source_importpath,
+            source = source,
+            package = package,
+            self_package = self_package,
+            aux_files = aux_files,
+            mockgen_tool = mockgen_tool,
+            mockgen_args = mockgen_args,
+            imports = imports,
+            copyright_file = copyright_file,
+            mock_names = mock_names,
+            **kwargs
+        )
+    else:
+        _gomock_reflect(
+            name = name,
+            out = out,
+            library = library,
+            interfaces = interfaces,
+            package = package,
+            self_package = self_package,
+            mockgen_tool = mockgen_tool,
+            mockgen_args = mockgen_args,
+            imports = imports,
+            copyright_file = copyright_file,
+            mock_names = mock_names,
+            **kwargs
+        )
+
+def _gomock_reflect(name, library, out, mockgen_tool, **kwargs):
+    interfaces = kwargs.pop("interfaces", None)
+    mockgen_model_lib = kwargs.pop("mockgen_model_library", _MOCKGEN_MODEL_LIB)
+
+    prog_src = name + "_gomock_prog"
+    prog_src_out = prog_src + ".go"
+    _gomock_prog_gen(
+        name = prog_src,
+        interfaces = interfaces,
+        library = library,
+        out = prog_src_out,
+        mockgen_tool = mockgen_tool,
+    )
+    prog_bin = name + "_gomock_prog_bin"
+    go_binary(
+        name = prog_bin,
+        srcs = [prog_src_out],
+        deps = [library, mockgen_model_lib],
+    )
+    _gomock_prog_exec(
+        name = name,
+        interfaces = interfaces,
+        library = library,
+        out = out,
+        prog_bin = prog_bin,
+        mockgen_tool = mockgen_tool,
+        **kwargs
+    )
+
+def _gomock_prog_gen_impl(ctx):
+    args = ["-prog_only"]
+    args.append(ctx.attr.library[GoInfo].importpath)
+    args.append(",".join(ctx.attr.interfaces))
+
+    cmd = ctx.file.mockgen_tool
+    out = ctx.outputs.out
+    ctx.actions.run_shell(
+        outputs = [out],
+        tools = [cmd],
+        command = """
+           {cmd} {args} > {out}
+        """.format(
+            cmd = "$(pwd)/" + cmd.path,
+            args = " ".join(args),
+            out = out.path,
+        ),
+        mnemonic = "GoMockReflectProgOnlyGen",
+    )
+
+_gomock_prog_gen = rule(
+    _gomock_prog_gen_impl,
+    attrs = {
+        "library": attr.label(
+            doc = "The target the Go library is at to look for the interfaces in. When this is set and source is not set, mockgen will use its reflect code to generate the mocks. If source is set, its dependencies will be included in the GOPATH that mockgen will be run in.",
+            providers = [GoInfo],
+            mandatory = True,
+        ),
+        "out": attr.output(
+            doc = "The new Go source file put the mock generator code",
+            mandatory = True,
+        ),
+        "interfaces": attr.string_list(
+            allow_empty = False,
+            doc = "The names of the Go interfaces to generate mocks for. If not set, all of the interfaces in the library or source file will have mocks generated for them.",
+            mandatory = True,
+        ),
+        "mockgen_tool": attr.label(
+            doc = "The mockgen tool to run",
+            default = _MOCKGEN_TOOL,
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+            mandatory = False,
+        ),
+        "_go_context_data": attr.label(
+            default = "@io_bazel_rules_go//:go_context_data",
+        ),
+    },
+    toolchains = [GO_TOOLCHAIN],
+)
+
+def _gomock_prog_exec_impl(ctx):
+    go = go_context(ctx, include_deprecated_properties = False)
+
+    args = ["-exec_only", ctx.file.prog_bin.path]
+    args, needed_files = _handle_shared_args(ctx, args)
+
+    # annoyingly, the interfaces join has to go after the importpath so we can't
+    # share those.
+    args.append(ctx.attr.library[GoInfo].importpath)
+    args.append(",".join(ctx.attr.interfaces))
+
+    ctx.actions.run_shell(
+        outputs = [ctx.outputs.out],
+        inputs = needed_files + [ctx.file.prog_bin, go.sdk.go],
+        tools = [
+            ctx.file.mockgen_tool,
+            go.sdk.go,
+        ],
+        command = """
+            export GOROOT=$(pwd)/{goroot} &&
+            export PATH=$GOROOT/bin:$PATH &&
+            {cmd} {args} > {out}""".format(
+            goroot = go.sdk.root_file.dirname,
+            cmd = "$(pwd)/" + ctx.file.mockgen_tool.path,
+            args = " ".join(args),
+            out = ctx.outputs.out.path,
+        ),
+        env = {
+            # GOCACHE is required starting in Go 1.12
+            "GOCACHE": "./.gocache",
+        },
+        mnemonic = "GoMockReflectExecOnlyGen",
+    )
+
+_gomock_prog_exec = rule(
+    _gomock_prog_exec_impl,
+    attrs = {
+        "library": attr.label(
+            doc = "The target the Go library is at to look for the interfaces in. When this is set and source is not set, mockgen will use its reflect code to generate the mocks. If source is set, its dependencies will be included in the GOPATH that mockgen will be run in.",
+            providers = [GoInfo],
+            mandatory = True,
+        ),
+        "out": attr.output(
+            doc = "The new Go source file to put the generated mock code",
+            mandatory = True,
+        ),
+        "interfaces": attr.string_list(
+            allow_empty = False,
+            doc = "The names of the Go interfaces to generate mocks for. If not set, all of the interfaces in the library or source file will have mocks generated for them.",
+            mandatory = True,
+        ),
+        "package": attr.string(
+            doc = "The name of the package the generated mocks should be in. If not specified, uses mockgen's default.",
+        ),
+        "self_package": attr.string(
+            doc = "The full package import path for the generated code. The purpose of this flag is to prevent import cycles in the generated code by trying to include its own package. This can happen if the mock's package is set to one of its inputs (usually the main one) and the output is stdio so mockgen cannot detect the final output package. Setting this flag will then tell mockgen which import to exclude.",
+        ),
+        "imports": attr.string_dict(
+            doc = "Dictionary of name-path pairs of explicit imports to use.",
+        ),
+        "mock_names": attr.string_dict(
+            doc = "Dictionary of interfaceName-mockName pairs of explicit mock names to use. Mock names default to 'Mock'+ interfaceName suffix.",
+            default = {},
+        ),
+        "copyright_file": attr.label(
+            doc = "Optional file containing copyright to prepend to the generated contents.",
+            allow_single_file = True,
+            mandatory = False,
+        ),
+        "prog_bin": attr.label(
+            doc = "The program binary generated by mockgen's -prog_only and compiled by bazel.",
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+            mandatory = True,
+        ),
+        "mockgen_tool": attr.label(
+            doc = "The mockgen tool to run",
+            default = _MOCKGEN_TOOL,
+            allow_single_file = True,
+            executable = True,
+            cfg = "exec",
+            mandatory = False,
+        ),
+        "mockgen_args": attr.string_list(
+            doc = "Additional arguments to pass to the mockgen tool",
+            mandatory = False,
+            default = [],
+        ),
+        "_go_context_data": attr.label(
+            default = "@io_bazel_rules_go//:go_context_data",
+        ),
+    },
+    toolchains = [GO_TOOLCHAIN],
+)
+
+def _handle_shared_args(ctx, args):
+    needed_files = []
+
+    if ctx.attr.package != "":
+        args += ["-package", ctx.attr.package]
+    if ctx.attr.self_package != "":
+        args += ["-self_package", ctx.attr.self_package]
+    if len(ctx.attr.imports) > 0:
+        imports = ",".join(["{0}={1}".format(name, pkg) for name, pkg in ctx.attr.imports.items()])
+        args += ["-imports", imports]
+    if ctx.file.copyright_file != None:
+        args += ["-copyright_file", ctx.file.copyright_file.path]
+        needed_files.append(ctx.file.copyright_file)
+    if len(ctx.attr.mock_names) > 0:
+        mock_names = ",".join(["{0}={1}".format(name, pkg) for name, pkg in ctx.attr.mock_names.items()])
+        args += ["-mock_names", mock_names]
+    if ctx.attr.mockgen_args:
+        args += ctx.attr.mockgen_args
+
+    return args, needed_files

--- a/bazel/rules/tools.go
+++ b/bazel/rules/tools.go
@@ -1,0 +1,3 @@
+package rules
+
+import _ "go.uber.org/mock/mockgen/model"

--- a/bazel/tests/README.rst
+++ b/bazel/tests/README.rst
@@ -1,0 +1,17 @@
+gomock
+=====================
+
+Tests that ensure the gomock rules can be called correctly under different input permutations.
+
+reflective
+------------------------
+Checks that gomock can be run in "reflective" mode when passed a `GoLibrary` and `interfaces`.
+
+source
+------------------------
+Checks that gomock can be run in "source" mode when passed a `GoLibrary` and `source`.
+
+source_with_importpath
+------------------------
+Checks that gomock can be run in "source" mode when passed an `importpath` and `source`.
+This test case also demonstrates the circumstance in which `importpath` is necessary to prevent a circular dependency.

--- a/bazel/tests/reflective/BUILD.bazel
+++ b/bazel/tests/reflective/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//rules:gomock.bzl", "gomock")
+
+
+go_library(
+    name = "client",
+    srcs = [
+        "client.go",
+    ],
+    importpath = "github.com/bazelbuild/rules_go/gomock/client",
+    visibility = ["//visibility:public"],
+)
+
+# Build the mocks using reflective mode (i.e. without passing source)
+gomock(
+    name = "mocks",
+    out = "client_mock.go",
+    interfaces = ["Client"],
+    library = ":client",
+    package = "client",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "client_test",
+    srcs = [
+        "client_mock.go",
+        "client_test.go",
+    ],
+    embed = [":client"],
+    deps = ["@org_uber_go_mock//gomock"],
+)

--- a/bazel/tests/reflective/client.go
+++ b/bazel/tests/reflective/client.go
@@ -1,0 +1,5 @@
+package client
+
+type Client interface {
+	Connect(string) int
+}

--- a/bazel/tests/reflective/client_test.go
+++ b/bazel/tests/reflective/client_test.go
@@ -1,0 +1,3 @@
+package client
+
+var _ Client = (*MockClient)(nil)

--- a/bazel/tests/source/BUILD.bazel
+++ b/bazel/tests/source/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//rules:gomock.bzl", "gomock")
+
+
+go_library(
+    name = "client",
+    srcs = [
+        "client.go",
+        "client_wrapper.go",
+    ],
+    importpath = "go.uber.org/mock/bazel/tests/source",
+    visibility = ["//visibility:public"],
+)
+
+gomock(
+    name = "client_mocks",
+    out = "client_mock.go",
+    library = ":client",
+    package = "client",
+    source = "client.go",
+    visibility = ["//visibility:public"],
+)
+
+gomock(
+    name = "wrapper_mocks",
+    out = "wrapper_mock.go",
+    aux_files = {
+        "client.go": "go.uber.org/mock/bazel/tests/source",
+    },
+    library = ":client",
+    package = "client",
+    self_package = "go.uber.org/mock/bazel/tests/source",
+    source = "client_wrapper.go",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "client_test",
+    srcs = [
+        "client_mock.go",
+        "client_test.go",
+        "wrapper_mock.go",
+    ],
+    embed = [":client"],
+    deps = ["@org_uber_go_mock//gomock"],
+)

--- a/bazel/tests/source/client.go
+++ b/bazel/tests/source/client.go
@@ -1,0 +1,5 @@
+package client
+
+type Client interface {
+	Connect(string) int
+}

--- a/bazel/tests/source/client_test.go
+++ b/bazel/tests/source/client_test.go
@@ -1,0 +1,3 @@
+package client
+
+var _ Client = (*MockClient)(nil)

--- a/bazel/tests/source/client_wrapper.go
+++ b/bazel/tests/source/client_wrapper.go
@@ -1,0 +1,6 @@
+package client
+
+type ClientWrapper interface {
+	Client
+	Close() error
+}

--- a/bazel/tests/source_with_importpath/BUILD.bazel
+++ b/bazel/tests/source_with_importpath/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//rules:gomock.bzl", "gomock")
+
+# For this test, the mock is included as part of the library
+go_library(
+    name = "client",
+    srcs = [
+        "client.go",
+        "client_mock.go",
+    ],
+    importpath = "go.uber.org/mock/bazel/tests/source_with_importpath",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_uber_go_mock//gomock",
+    ],
+)
+
+# Pass importpath instead of library to the generation step
+# Passing library instead of importpath here will cause a circular dependency
+gomock(
+    name = "mocks",
+    out = "client_mock.go",
+    package = "client",
+    source = "client.go",
+    source_importpath = "go.uber.org/mock/bazel/tests/source_with_importpath",
+    visibility = ["//visibility:public"],
+)
+
+# Don't include client_mock.go as a source file, instead use it from the library
+go_test(
+    name = "client_test",
+    srcs = [
+        "client_test.go",
+    ],
+    embed = [":client"],
+)

--- a/bazel/tests/source_with_importpath/client.go
+++ b/bazel/tests/source_with_importpath/client.go
@@ -1,0 +1,5 @@
+package client
+
+type Client interface {
+	Connect(string) int
+}

--- a/bazel/tests/source_with_importpath/client_test.go
+++ b/bazel/tests/source_with_importpath/client_test.go
@@ -1,0 +1,3 @@
+package client
+
+var _ Client = (*MockClient)(nil)


### PR DESCRIPTION
This PR copies the gomock definition and tests from rules_go with minimal changes:

* Replacing github.com/golang/mock with go.uber.org/mock
* Replacing `load` statements accordingly
* Setting up a Bazel and a Go module in the "bazel" directory

Note that the Go module uses v0.4.0 of go.uber.org/mock, because the latest version is no longer compatible with the gomock rule (https://github.com/bazel-contrib/rules_go/issues/4153). We will update the rule and mockgen version in subsequent PRs.

This is a first step in addressing #225