### PR TITLE
Use `_name` instead `argn` in case of conflict

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -818,16 +818,20 @@ func (g *generator) getArgNames(m *model.Method, in bool) []string {
 	for i, p := range params {
 		name := p.Name
 
-		if name == "" || name == "_" || g.nameExistsAsPackage(name) {
+		if name == "" || name == "_" {
 			name = fmt.Sprintf("arg%d", i)
+		} else if g.nameExistsAsPackage(name) {
+			name = "_" + name
 		}
 		argNames[i] = name
 	}
 	if m.Variadic != nil && in {
 		name := m.Variadic.Name
 
-		if name == "" || g.nameExistsAsPackage(name) {
+		if name == "" {
 			name = fmt.Sprintf("arg%d", len(params))
+		} else if g.nameExistsAsPackage(name) {
+			name = "_" + name
 		}
 		argNames = append(argNames, name)
 	}

--- a/mockgen/mockgen_test.go
+++ b/mockgen/mockgen_test.go
@@ -276,9 +276,10 @@ func findMethod(t *testing.T, identifier, methodName string, lines []string) int
 
 func TestGetArgNames(t *testing.T) {
 	for _, testCase := range []struct {
-		name     string
-		method   *model.Method
-		expected []string
+		name       string
+		method     *model.Method
+		packageMap map[string]string
+		expected   []string
 	}{
 		{
 			name: "NamedArg",
@@ -328,9 +329,43 @@ func TestGetArgNames(t *testing.T) {
 			},
 			expected: []string{"firstArg", "arg1"},
 		},
+		{
+			name: "ArgNameConflictsWithPackage",
+			method: &model.Method{
+				In: []*model.Parameter{
+					{
+						Name: "fmt",
+						Type: &model.NamedType{Type: "int"},
+					},
+					{
+						Name: "secondArg",
+						Type: &model.NamedType{Type: "string"},
+					},
+				},
+			},
+			packageMap: map[string]string{"fmt": "fmt"},
+			expected:   []string{"_fmt", "secondArg"},
+		},
+		{
+			name: "VariadicArgNameConflictsWithPackage",
+			method: &model.Method{
+				In: []*model.Parameter{
+					{
+						Name: "firstArg",
+						Type: &model.NamedType{Type: "int"},
+					},
+				},
+				Variadic: &model.Parameter{
+					Name: "fmt",
+					Type: &model.NamedType{Type: "string"},
+				},
+			},
+			packageMap: map[string]string{"fmt": "fmt"},
+			expected:   []string{"firstArg", "_fmt"},
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			g := generator{}
+			g := generator{packageMap: testCase.packageMap}
 
 			result := g.getArgNames(testCase.method, true)
 			if !reflect.DeepEqual(result, testCase.expected) {


### PR DESCRIPTION
## Problem

When an argument name conflicts with a package name (e.g. a parameter named `fmt` while the `fmt` package is imported), `getArgNames` replaces it with a generic `argN`. This loses the original semantic meaning of the parameter name.

## Fix

Separate the two cases:
- Empty or `_` names → still get `argN`
- Package name conflicts → prefix with underscore (`fmt` → `_fmt`)

This preserves readability in the generated mock code while still avoiding the naming collision.

## Changes

- `mockgen/mockgen.go`: split the condition for both regular and variadic params
- `mockgen/mockgen_test.go`: added test cases for package name conflicts (regular and variadic)