### PR TITLE
Bump go.mod to 1.23 and remove alias replacements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
   go:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x] # oldest version that can build go mock and official supported go versions
+        go-version: [1.23.x, 1.24.x] # oldest version that can build go mock and official supported go versions
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/mock
 
-go 1.22
+go 1.23
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/mockgen/internal/tests/alias/mock/interfaces.go
+++ b/mockgen/internal/tests/alias/mock/interfaces.go
@@ -286,10 +286,10 @@ func (m *MockBazer) EXPECT() *MockBazerMockRecorder {
 }
 
 // Baz mocks base method.
-func (m *MockBazer) Baz(arg0 alias.FooerAlias) alias.FooerAlias {
+func (m *MockBazer) Baz(arg0 alias.Fooer) alias.Fooer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Baz", arg0)
-	ret0, _ := ret[0].(alias.FooerAlias)
+	ret0, _ := ret[0].(alias.Fooer)
 	return ret0
 }
 
@@ -306,19 +306,19 @@ type MockBazerBazCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockBazerBazCall) Return(arg0 alias.FooerAlias) *MockBazerBazCall {
+func (c *MockBazerBazCall) Return(arg0 alias.Fooer) *MockBazerBazCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBazerBazCall) Do(f func(alias.FooerAlias) alias.FooerAlias) *MockBazerBazCall {
+func (c *MockBazerBazCall) Do(f func(alias.Fooer) alias.Fooer) *MockBazerBazCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBazerBazCall) DoAndReturn(f func(alias.FooerAlias) alias.FooerAlias) *MockBazerBazCall {
+func (c *MockBazerBazCall) DoAndReturn(f func(alias.Fooer) alias.Fooer) *MockBazerBazCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mockgen/internal/tests/generics/go.mod
+++ b/mockgen/internal/tests/generics/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/mock/mockgen/internal/tests/generics
 
-go 1.22
+go 1.23
 
 replace go.uber.org/mock => ../../../..
 

--- a/mockgen/internal/tests/package_mode/mock/interfaces.go
+++ b/mockgen/internal/tests/package_mode/mock/interfaces.go
@@ -1382,7 +1382,7 @@ func (m *MockEarth) EXPECT() *MockEarthMockRecorder {
 }
 
 // AddHumans mocks base method.
-func (m *MockEarth) AddHumans(arg0 int) []package_mode.Human {
+func (m *MockEarth) AddHumans(arg0 package_mode.HumansCount) []package_mode.Human {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddHumans", arg0)
 	ret0, _ := ret[0].([]package_mode.Human)
@@ -1408,22 +1408,22 @@ func (c *MockEarthAddHumansCall) Return(arg0 []package_mode.Human) *MockEarthAdd
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockEarthAddHumansCall) Do(f func(int) []package_mode.Human) *MockEarthAddHumansCall {
+func (c *MockEarthAddHumansCall) Do(f func(package_mode.HumansCount) []package_mode.Human) *MockEarthAddHumansCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockEarthAddHumansCall) DoAndReturn(f func(int) []package_mode.Human) *MockEarthAddHumansCall {
+func (c *MockEarthAddHumansCall) DoAndReturn(f func(package_mode.HumansCount) []package_mode.Human) *MockEarthAddHumansCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HumanPopulation mocks base method.
-func (m *MockEarth) HumanPopulation() int {
+func (m *MockEarth) HumanPopulation() package_mode.HumansCount {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HumanPopulation")
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(package_mode.HumansCount)
 	return ret0
 }
 
@@ -1440,19 +1440,19 @@ type MockEarthHumanPopulationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockEarthHumanPopulationCall) Return(arg0 int) *MockEarthHumanPopulationCall {
+func (c *MockEarthHumanPopulationCall) Return(arg0 package_mode.HumansCount) *MockEarthHumanPopulationCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockEarthHumanPopulationCall) Do(f func() int) *MockEarthHumanPopulationCall {
+func (c *MockEarthHumanPopulationCall) Do(f func() package_mode.HumansCount) *MockEarthHumanPopulationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockEarthHumanPopulationCall) DoAndReturn(f func() int) *MockEarthHumanPopulationCall {
+func (c *MockEarthHumanPopulationCall) DoAndReturn(f func() package_mode.HumansCount) *MockEarthHumanPopulationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/mockgen/internal/tests/typed/go.mod
+++ b/mockgen/internal/tests/typed/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/mock/mockgen/internal/tests/typed
 
-go 1.22
+go 1.23
 
 replace go.uber.org/mock => ../../../..
 

--- a/mockgen/package_mode.go
+++ b/mockgen/package_mode.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"go/ast"
 	"go/types"
 	"strings"
 
@@ -18,20 +17,6 @@ var (
 
 type packageModeParser struct {
 	pkgName string
-
-	// Mapping from underlying types to aliases used within the package source.
-	//
-	// We prefer to use aliases used in the source rather than underlying type names
-	// as those may be unexported or internal.
-	// TODO(joaks): Once mock is Go1.23+ only, we can remove this
-	// as the casing for types.Alias will automatically handle this
-	// in all cases.
-	aliasReplacements map[types.Type]aliasReplacement
-}
-
-type aliasReplacement struct {
-	name string
-	pkg  string
 }
 
 func (p *packageModeParser) parsePackage(packageName string, ifaces []string) (*model.Package, error) {
@@ -41,8 +26,6 @@ func (p *packageModeParser) parsePackage(packageName string, ifaces []string) (*
 	if err != nil {
 		return nil, fmt.Errorf("load package: %w", err)
 	}
-
-	p.buildAliasReplacements(pkg)
 
 	interfaces, err := p.extractInterfacesFromPackage(pkg, ifaces)
 	if err != nil {
@@ -54,90 +37,6 @@ func (p *packageModeParser) parsePackage(packageName string, ifaces []string) (*
 		PkgPath:    packageName,
 		Interfaces: interfaces,
 	}, nil
-}
-
-// buildAliasReplacements finds and records any references to aliases
-// within the given package's source.
-// These aliases will be preferred when parsing types
-// over the underlying name counterparts, as those may be unexported / internal.
-//
-// If a type has more than one alias within the source package,
-// the latest one to be inspected will be the one used for mapping.
-// This is fine, since all aliases and their underlying types are interchangeable
-// from a type-checking standpoint.
-func (p *packageModeParser) buildAliasReplacements(pkg *packages.Package) {
-	p.aliasReplacements = make(map[types.Type]aliasReplacement)
-
-	// checkIdent checks if the given identifier exists
-	// in the given package as an alias, and adds it to
-	// the alias replacements map if so.
-	checkIdent := func(pkg *types.Package, ident string) bool {
-		scope := pkg.Scope()
-		if scope == nil {
-			return true
-		}
-		obj := scope.Lookup(ident)
-		if obj == nil {
-			return true
-		}
-		objTypeName, ok := obj.(*types.TypeName)
-		if !ok {
-			return true
-		}
-		if !objTypeName.IsAlias() {
-			return true
-		}
-		typ := objTypeName.Type()
-		if typ == nil {
-			return true
-		}
-		p.aliasReplacements[typ] = aliasReplacement{
-			name: objTypeName.Name(),
-			pkg:  pkg.Path(),
-		}
-		return false
-
-	}
-
-	for _, f := range pkg.Syntax {
-		fileScope, ok := pkg.TypesInfo.Scopes[f]
-		if !ok {
-			continue
-		}
-		ast.Inspect(f, func(node ast.Node) bool {
-
-			// Simple identifiers: check if it is an alias
-			// from the source package.
-			if ident, ok := node.(*ast.Ident); ok {
-				return checkIdent(pkg.Types, ident.String())
-			}
-
-			// Selector expressions: check if it is an alias
-			// from the package represented by the qualifier.
-			selExpr, ok := node.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-
-			x, sel := selExpr.X, selExpr.Sel
-			xident, ok := x.(*ast.Ident)
-			if !ok {
-				return true
-			}
-
-			xObj := fileScope.Lookup(xident.String())
-			pkgName, ok := xObj.(*types.PkgName)
-			if !ok {
-				return true
-			}
-
-			xPkg := pkgName.Imported()
-			if xPkg == nil {
-				return true
-			}
-			return checkIdent(xPkg, sel.String())
-		})
-	}
 }
 
 func (p *packageModeParser) loadPackage(packageName string) (*packages.Package, error) {
@@ -298,14 +197,6 @@ func (p *packageModeParser) parseType(t types.Type) (model.Type, error) {
 		var pkg string
 		if object.Obj().Pkg() != nil {
 			pkg = object.Obj().Pkg().Path()
-		}
-
-		// If there was an alias to this type used somewhere in the source,
-		// use that alias instead of the underlying type,
-		// since the underlying type might be unexported.
-		if alias, ok := p.aliasReplacements[t]; ok {
-			name = alias.name
-			pkg = alias.pkg
 		}
 
 		// TypeArgs method not available for aliases in go1.22

--- a/mockgen/package_mode_test.go
+++ b/mockgen/package_mode_test.go
@@ -314,7 +314,10 @@ func Test_packageModeParser_parsePackage(t *testing.T) {
 								Name: "AddHumans",
 								In: []*model.Parameter{
 									{
-										Type: model.PredeclaredType("int"),
+										Type: &model.NamedType{
+											Package: "go.uber.org/mock/mockgen/internal/tests/package_mode",
+											Type: "HumansCount",
+										},
 									},
 								},
 								Out: []*model.Parameter{
@@ -333,7 +336,10 @@ func Test_packageModeParser_parsePackage(t *testing.T) {
 								Name: "HumanPopulation",
 								Out: []*model.Parameter{
 									{
-										Type: model.PredeclaredType("int"),
+										Type: &model.NamedType{
+											Package: "go.uber.org/mock/mockgen/internal/tests/package_mode",
+											Type: "HumansCount",
+										},
 									},
 								},
 							},
@@ -444,13 +450,13 @@ func TestAliases(t *testing.T) {
 					In: []*model.Parameter{{
 						Type: &model.NamedType{
 							Package: "go.uber.org/mock/mockgen/internal/tests/alias",
-							Type:    "FooerAlias",
+							Type:    "Fooer",
 						},
 					}},
 					Out: []*model.Parameter{{
 						Type: &model.NamedType{
 							Package: "go.uber.org/mock/mockgen/internal/tests/alias",
-							Type:    "FooerAlias",
+							Type:    "Fooer",
 						},
 					}},
 				}},

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/uber-go/mock/tools
 
-go 1.22
+go 1.23
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
Alias replacements derived from syntax were introduced in #220 as a way to ensure the aliases used in source code were also used. This helped ensure packages mode worked on go1.22, which didn't have explicit alias node support in the `go/types` package.

Alias replacements have a couple issues:
* They flat out replace any would-be references to an underlying type with an alias type.
* They don't properly handle aliases to generic type instantiations (ref: #243)

Now that go1.24 is released, we can bump `go.mod` to go1.23, which means we can ensure `go/types` has an explicit `types.Alias` node for type aliases, and we can remove the alias replacement logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated support to Go version 1.24.x in testing workflows.
- **Refactor**
	- Improved type handling for method signatures, replacing certain type aliases and primitive types with more precise or underlying types in generated mocks.
	- Removed the alias replacement mechanism for type parsing to simplify internal logic.
- **Tests**
	- Updated test expectations to align with changes in type handling.
- **Chores**
	- Updated Go module files to use Go 1.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->