### PR TITLE
Prepare release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-- No changes yet.
+## 0.5.2 (28 Apr 2025)
+
+### Fixed
+- [#248][]: Fixed an issue with type aliases not being included in generated code correctly.
+
+[#248]: https://github.com/uber-go/mock/pull/248
 
 ## 0.5.1 (7 Apr 2025)
 ### Fixed


### PR DESCRIPTION
Prepare the changelog for a v0.5.2 release containing a bug fix caused by outdated go version and alias replacements logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to reflect the new 0.5.2 release, including a fix for type aliases not being properly included in generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->