### PR TITLE
panic: fix nil pointer dereference when x is a nil pointer

### DIFF
--- a/gomock/string.go
+++ b/gomock/string.go
@@ -12,6 +12,10 @@ func getString(x any) string {
 	if isGeneratedMock(x) {
 		return fmt.Sprintf("%T", x)
 	}
+	typ := reflect.TypeOf(x)
+	if typ.Kind() == reflect.Ptr && typ.IsNil() {
+		return "nil"
+	}
 	if s, ok := x.(fmt.Stringer); ok {
 		return s.String()
 	}

--- a/gomock/string.go
+++ b/gomock/string.go
@@ -12,7 +12,7 @@ func getString(x any) string {
 	if isGeneratedMock(x) {
 		return fmt.Sprintf("%T", x)
 	}
-	typ := reflect.TypeOf(x)
+	typ := reflect.ValueOf(x)
 	if typ.Kind() == reflect.Ptr && typ.IsNil() {
 		return "nil"
 	}


### PR DESCRIPTION
when expected call fails to find a match, the error log message prints the actual values of the called method args 
if one of the args is a nil pointer, function getString will panic on line https://github.com/uber-go/mock/blob/main/gomock/string.go#L16 

```
panic: value method time.Duration.String called using nil *Duration pointer

goroutine 25 [running]:
time.(*Duration).String(0x103ee8b80?)
        <autogenerated>:1 +0x78
go.uber.org/mock/gomock.getString({0x103680500, 0x0})
        /Volumes/Go/pkg/mod/go.uber.org/mock@v0.5.0/gomock/string.go:16 +0x98
go.uber.org/mock/gomock.(*Controller).Call.func1(0x1400049e390, {0x10369d880, 0x140000e8678}, {0x1032d9bec, 0x16}, {0x14000842b10, 0x3, 0x3})
        /Volumes/Go/pkg/mod/go.uber.org/mock@v0.5.0/gomock/controller.go:212 +0x198
go.uber.org/mock/gomock.(*Controller).Call(0x1400049e390, {0x10369d880, 0x140000e8678}, {0x1032d9bec, 0x16}, {0x14000842b10, 0x3, 0x3})
        /Volumes/Go/pkg/mod/go.uber.org/mock@v0.5.0/gomock/controller.go:230 +0x6c
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of nil pointers to prevent errors when converting them to strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->