### PR TITLE
Fix release action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ mockgen/mockgen
 
 # vendor directory used for IDEs
 /vendor
+
+# tools
+/bin
+# coverage files
+/cover.out
+/cover.html

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+BIN = bin
+
+export GO111MODULE=on
+export GOBIN ?= $(shell pwd)/$(BIN)
+
+GO_FILES = $(shell find . \
+	   -path '*/.*' -prune -o \
+	   '(' -type f -a -name '*.go' ')' -print)
+
+EXTRACT_CHANGELOG = $(BIN)/extract-changelog
+
+.PHONY: all
+all: build test
+
+.PHONY: build
+build:
+	go build ./...
+
+.PHONY: test
+test:
+	go test -v -race ./...
+
+.PHONY: cover
+cover:
+	go test -race -coverprofile=cover.out -coverpkg=./... ./...
+	go tool cover -html=cover.out -o cover.html
+
+$(EXTRACT_CHANGELOG): tools/cmd/extract-changelog/main.go
+	cd tools && go install github.com/uber-go/mock/tools/cmd/extract-changelog


### PR DESCRIPTION
This adds a Makefile to fix the fact that the goreleaser tries to call `make bin/extract-changelog`.
Now that should succeed.

Signed-off-by: Vihang Mehta <vihang@gimletlabs.ai>
