### PR TITLE
Avoid unnecessary map allocation in parseExcludeInterfaces

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -214,17 +214,17 @@ func parseMockNames(names string) map[string]string {
 
 func parseExcludeInterfaces(names string) map[string]struct{} {
 	splitNames := strings.Split(names, ",")
-	namesSet := make(map[string]struct{}, len(splitNames))
+	var namesSet map[string]struct{}
+
 	for _, name := range splitNames {
-		if name == "" {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
 			continue
 		}
-
-		namesSet[name] = struct{}{}
-	}
-
-	if len(namesSet) == 0 {
-		return nil
+		if namesSet == nil {
+			namesSet = make(map[string]struct{}, len(splitNames))
+		}
+		namesSet[trimmed] = struct{}{}
 	}
 
 	return namesSet


### PR DESCRIPTION
Hi, I found that when `*excludeInterfaces` at [line 79](https://github.com/uber-go/mock/blob/871d86bb6f8b22d0c4d250ebca1f9d674f6e6d1e/mockgen/parse.go#L79) in the file `mockgen/parse.go` is in the form of ",,,," and " , , ", the function `parseExcludeInterfaces` will create unnecessary map allocation or maintain whitespace entries as the names of excluded interfaces [[Link]](https://github.com/uber-go/mock/blob/871d86bb6f8b22d0c4d250ebca1f9d674f6e6d1e/mockgen/mockgen.go#L217), which is not necessary.

With this patch, the function `parseExcludeInterfaces` now returns nil instead, which more accurately represents the absence of exclusions and avoids a redundant allocation.

This change is fully backward-compatible and requires no changes in downstream code. I think this patch can improve the code quality due to the better input validation and format check. Please let me know whether you need more adjustment on the patch.