### PR TITLE
Support for archive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ export PATH=$PATH:$(go env GOPATH)/bin
 
 ## Running mockgen
 
-`mockgen` has three modes of operation: archive, source and reflect.
+`mockgen` has three modes of operation: archive, source and package.
 
 ### Archive mode
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ export PATH=$PATH:$(go env GOPATH)/bin
 ### Archive mode
 
 Archive mode generates mock interfaces from a package archive
-file (.a). It is enabled by using the -archive flag and two
-non-flag arguments: an import path, and a comma-separated
-list of symbols.
+file (.a). It is enabled by using the -archive flag. An import
+path and a comma-separated list of symbols should be provided
+as a non-flag argument to the command.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ export PATH=$PATH:$(go env GOPATH)/bin
 ### Archive mode
 
 Archive mode generates mock interfaces from a package archive
-file (.a). It is enabled by using the -archive flag, the import
-path is also needed as a non-flag argument. No other flags are
-required.
+file (.a). It is enabled by using the -archive flag and two
+non-flag arguments: an import path, and a comma-separated
+list of symbols.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,23 @@ export PATH=$PATH:$(go env GOPATH)/bin
 
 ## Running mockgen
 
-`mockgen` has two modes of operation: source and package.
+`mockgen` has three modes of operation: archive, source and reflect.
+
+### Archive mode
+
+Archive mode generates mock interfaces from a package archive
+file (.a). It is enabled by using the -archive flag, the import
+path is also needed as a non-flag argument. No other flags are
+required.
+
+Example:
+
+```bash
+# Build the package to a archive.
+go build -o pkg.a database/sql/driver
+
+mockgen -archive=pkg.a database/sql/driver
+```
 
 ### Source mode
 
@@ -76,6 +92,8 @@ mockgen . Conn,Driver
 The `mockgen` command is used to generate source code for a mock
 class given a Go source file containing interfaces to be mocked.
 It supports the following flags:
+
+- `-archive`: A package archive file containing interfaces to be mocked.
 
 - `-source`: A file containing interfaces to be mocked.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Example:
 # Build the package to a archive.
 go build -o pkg.a database/sql/driver
 
-mockgen -archive=pkg.a database/sql/driver
+mockgen -archive=pkg.a database/sql/driver Conn,Driver
 ```
 
 ### Source mode

--- a/mockgen/archive.go
+++ b/mockgen/archive.go
@@ -31,8 +31,9 @@ func archiveMode(importPath string, symbols []string, archive string) (*model.Pa
 	}
 
 	pkg := &model.Package{
-		Name:    tp.Name(),
-		PkgPath: tp.Path(),
+		Name:       tp.Name(),
+		PkgPath:    tp.Path(),
+		Interfaces: make([]*model.Interface, 0, len(symbols)),
 	}
 	for _, name := range symbols {
 		m := tp.Scope().Lookup(name)

--- a/mockgen/archive.go
+++ b/mockgen/archive.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"go/token"
+	"go/types"
+	"log"
+	"os"
+
+	"go.uber.org/mock/mockgen/model"
+
+	"golang.org/x/tools/go/gcexportdata"
+)
+
+func archiveMode(importpath, archive string) (*model.Package, error) {
+	f, err := os.Open(archive)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	r, err := gcexportdata.NewReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("read export data %q: %v", archive, err)
+	}
+
+	fset := token.NewFileSet()
+	imports := make(map[string]*types.Package)
+	tp, err := gcexportdata.Read(r, fset, imports, importpath)
+	if err != nil {
+		return nil, err
+	}
+
+	pkg := &model.Package{
+		Name:    tp.Name(),
+		PkgPath: tp.Path(),
+	}
+	for _, name := range tp.Scope().Names() {
+		m := tp.Scope().Lookup(name)
+		tn, ok := m.(*types.TypeName)
+		if !ok {
+			continue
+		}
+		ti, ok := tn.Type().Underlying().(*types.Interface)
+		if !ok {
+			continue
+		}
+		it, err := model.InterfaceFromGoTypesType(ti)
+		if err != nil {
+			log.Fatal(err)
+		}
+		it.Name = m.Name()
+		pkg.Interfaces = append(pkg.Interfaces, it)
+	}
+	return pkg, nil
+}

--- a/mockgen/archive.go
+++ b/mockgen/archive.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/tools/go/gcexportdata"
 )
 
-func archiveMode(importpath, archive string) (*model.Package, error) {
+func archiveMode(importPath string, symbols []string, archive string) (*model.Package, error) {
 	f, err := os.Open(archive)
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func archiveMode(importpath, archive string) (*model.Package, error) {
 
 	fset := token.NewFileSet()
 	imports := make(map[string]*types.Package)
-	tp, err := gcexportdata.Read(r, fset, imports, importpath)
+	tp, err := gcexportdata.Read(r, fset, imports, importPath)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func archiveMode(importpath, archive string) (*model.Package, error) {
 		Name:    tp.Name(),
 		PkgPath: tp.Path(),
 	}
-	for _, name := range tp.Scope().Names() {
+	for _, name := range symbols {
 		m := tp.Scope().Lookup(name)
 		tn, ok := m.(*types.TypeName)
 		if !ok {

--- a/mockgen/archive.go
+++ b/mockgen/archive.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/token"
 	"go/types"
-	"log"
 	"os"
 
 	"go.uber.org/mock/mockgen/model"
@@ -47,7 +46,7 @@ func archiveMode(importPath string, symbols []string, archive string) (*model.Pa
 		}
 		it, err := model.InterfaceFromGoTypesType(ti)
 		if err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
 		it.Name = m.Name()
 		pkg.Interfaces = append(pkg.Interfaces, it)

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -261,7 +261,7 @@ Example:
 
 Archive mode generates mock interfaces from a package archive
 file (.a). It is enabled by using the -archive flag and two
-two non-flag arguments: an import path, and a comma-separated
+non-flag arguments: an import path, and a comma-separated
 list of symbols.
 Example:
 	mockgen -archive=pkg.a database/sql/driver Conn,Driver

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -102,7 +102,7 @@ func main() {
 		interfaces := strings.Split(flag.Arg(1), ",")
 		pkg, err = archiveMode(packageName, interfaces, *archive)
 
-	default: // reflect mode
+	default: // package mode
 		checkArgs()
 		packageName = flag.Arg(0)
 		interfaces := strings.Split(flag.Arg(1), ",")
@@ -117,9 +117,9 @@ func main() {
 				log.Fatalf("Parse package name failed: %v", err)
 			}
 
-			parser := packageModeParser{}
-			pkg, err = parser.parsePackage(packageName, interfaces)
 		}
+		parser := packageModeParser{}
+		pkg, err = parser.parsePackage(packageName, interfaces)
 	}
 
 	if err != nil {
@@ -253,7 +253,7 @@ func usage() {
 	flag.PrintDefaults()
 }
 
-const usageText = `mockgen has three modes of operation: archive, source and reflect.
+const usageText = `mockgen has three modes of operation: archive, source and package.
 
 Source mode generates mock interfaces from a source file.
 It is enabled by using the -source flag. Other flags that

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -54,6 +54,7 @@ var (
 )
 
 var (
+	archive                = flag.String("archive", "", "(archive mode) Input Go archive file; enables archive mode.")
 	source                 = flag.String("source", "", "(source mode) Input Go source file; enables source mode.")
 	destination            = flag.String("destination", "", "Output file; defaults to stdout.")
 	mockNames              = flag.String("mock_names", "", "Comma-separated interfaceName=mockName pairs of explicit mock names to use. Mock names default to 'Mock'+ interfaceName suffix.")
@@ -68,11 +69,10 @@ var (
 	typed                  = flag.Bool("typed", false, "Generate Type-safe 'Return', 'Do', 'DoAndReturn' function")
 	imports                = flag.String("imports", "", "(source mode) Comma-separated name=path pairs of explicit imports to use.")
 	auxFiles               = flag.String("aux_files", "", "(source mode) Comma-separated pkg=path pairs of auxiliary Go source files.")
-	excludeInterfaces      = flag.String("exclude_interfaces", "", "(source mode) Comma-separated names of interfaces to be excluded")
 	modelGob               = flag.String("model_gob", "", "Skip package/source loading entirely and use the gob encoded model.Package at the given path")
-
-	debugParser = flag.Bool("debug_parser", false, "Print out parser results only.")
-	showVersion = flag.Bool("version", false, "Print version.")
+	excludeInterfaces      = flag.String("exclude_interfaces", "", "Comma-separated names of interfaces to be excluded")
+	debugParser            = flag.Bool("debug_parser", false, "Print out parser results only.")
+	showVersion            = flag.Bool("version", false, "Print version.")
 )
 
 func main() {
@@ -93,6 +93,12 @@ func main() {
 		pkg, err = gobMode(*modelGob)
 	} else if *source != "" {
 		pkg, err = sourceMode(*source)
+	} else if *archive != "" {
+		if flag.NArg() != 1 {
+			usage()
+			log.Fatal("Expected exactly one argument")
+		}
+		pkg, err = archiveMode(flag.Arg(0), *archive)
 	} else {
 		if flag.NArg() != 2 {
 			usage()
@@ -155,6 +161,8 @@ func main() {
 	}
 	if *source != "" {
 		g.filename = *source
+	} else if *archive != "" {
+		g.filename = *archive
 	} else {
 		g.srcPackage = packageName
 		g.srcInterfaces = flag.Arg(1)
@@ -235,7 +243,14 @@ func usage() {
 	flag.PrintDefaults()
 }
 
-const usageText = `mockgen has two modes of operation: source and package.
+const usageText = `mockgen has three modes of operation: archive, source and reflect.
+
+Archive mode generates mock interfaces from a package archive
+file (.a). It is enabled by using the -archive flag, the import
+path is also needed as a non-flag argument. No other flags are
+required.
+Example:
+	mockgen -archive=pkg.a importpath
 
 Source mode generates mock interfaces from a source file.
 It is enabled by using the -source flag. Other flags that
@@ -245,7 +260,7 @@ Example:
 
 Package mode works by specifying the package and interface names.
 It is enabled by passing two non-flag arguments: an import path, and a
-comma-separated list of symbols. 
+comma-separated list of symbols.
 You can use "." to refer to the current path's package.
 Example:
 	mockgen database/sql/driver Conn,Driver

--- a/mockgen/model/model_gotypes.go
+++ b/mockgen/model/model_gotypes.go
@@ -42,8 +42,7 @@ func funcArgsFromGoTypesType(t *types.Signature) (in []*Parameter, variadic *Par
 		in = append(in, p)
 	}
 	if t.Variadic() {
-		p, err = parameterFromGoTypesType(t.Params().At(nin), true)
-		if err != nil {
+		if p, err = parameterFromGoTypesType(t.Params().At(nin), true); err != nil {
 			return
 		}
 		variadic = p

--- a/mockgen/model/model_gotypes.go
+++ b/mockgen/model/model_gotypes.go
@@ -1,0 +1,164 @@
+package model
+
+import (
+	"fmt"
+	"go/types"
+)
+
+// InterfaceFromGoTypesType returns a pointer to an interface for the
+// given reflection interface type.
+func InterfaceFromGoTypesType(it *types.Interface) (*Interface, error) {
+	intf := &Interface{}
+
+	for i := 0; i < it.NumMethods(); i++ {
+		mt := it.Method(i)
+		// TODO: need to skip unexported methods? or just raise an error?
+		m := &Method{
+			Name: mt.Name(),
+		}
+
+		var err error
+		m.In, m.Variadic, m.Out, err = funcArgsFromGoTypesType(mt.Type().(*types.Signature))
+		if err != nil {
+			return nil, err
+		}
+
+		intf.AddMethod(m)
+	}
+
+	return intf, nil
+}
+
+func funcArgsFromGoTypesType(t *types.Signature) (in []*Parameter, variadic *Parameter, out []*Parameter, err error) {
+	nin := t.Params().Len()
+	if t.Variadic() {
+		nin--
+	}
+	var p *Parameter
+	for i := 0; i < nin; i++ {
+		p, err = parameterFromGoTypesType(t.Params().At(i), false)
+		if err != nil {
+			return
+		}
+		in = append(in, p)
+	}
+	if t.Variadic() {
+		p, err = parameterFromGoTypesType(t.Params().At(nin), true)
+		if err != nil {
+			return
+		}
+		variadic = p
+	}
+	for i := 0; i < t.Results().Len(); i++ {
+		p, err = parameterFromGoTypesType(t.Results().At(i), false)
+		if err != nil {
+			return
+		}
+		out = append(out, p)
+	}
+	return
+}
+
+func parameterFromGoTypesType(v *types.Var, variadic bool) (*Parameter, error) {
+	t := v.Type()
+	if variadic {
+		t = t.(*types.Slice).Elem()
+	}
+	tt, err := typeFromGoTypesType(t)
+	if err != nil {
+		return nil, err
+	}
+	return &Parameter{Name: v.Name(), Type: tt}, nil
+}
+
+func typeFromGoTypesType(t types.Type) (Type, error) {
+	// Hack workaround for https://golang.org/issue/3853.
+	// This explicit check should not be necessary.
+	// if t == byteType {
+	// 	return PredeclaredType("byte"), nil
+	// }
+
+	if t, ok := t.(*types.Named); ok {
+		tn := t.Obj()
+		if tn.Pkg() == nil {
+			return PredeclaredType(tn.Name()), nil
+		}
+		return &NamedType{
+			Package: tn.Pkg().Path(),
+			Type:    tn.Name(),
+		}, nil
+	}
+
+	// only unnamed or predeclared types after here
+
+	// Lots of types have element types. Let's do the parsing and error checking for all of them.
+	var elemType Type
+	if t, ok := t.(interface{ Elem() types.Type }); ok {
+		var err error
+		elemType, err = typeFromGoTypesType(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	switch t := t.(type) {
+	case *types.Array:
+		return &ArrayType{
+			Len:  int(t.Len()),
+			Type: elemType,
+		}, nil
+	case *types.Basic:
+		return PredeclaredType(t.String()), nil
+	case *types.Chan:
+		var dir ChanDir
+		switch t.Dir() {
+		case types.RecvOnly:
+			dir = RecvDir
+		case types.SendOnly:
+			dir = SendDir
+		}
+		return &ChanType{
+			Dir:  dir,
+			Type: elemType,
+		}, nil
+	case *types.Signature:
+		in, variadic, out, err := funcArgsFromGoTypesType(t)
+		if err != nil {
+			return nil, err
+		}
+		return &FuncType{
+			In:       in,
+			Out:      out,
+			Variadic: variadic,
+		}, nil
+	case *types.Interface:
+		if t.NumMethods() == 0 {
+			return PredeclaredType("interface{}"), nil
+		}
+	case *types.Map:
+		kt, err := typeFromGoTypesType(t.Key())
+		if err != nil {
+			return nil, err
+		}
+		return &MapType{
+			Key:   kt,
+			Value: elemType,
+		}, nil
+	case *types.Pointer:
+		return &PointerType{
+			Type: elemType,
+		}, nil
+	case *types.Slice:
+		return &ArrayType{
+			Len:  -1,
+			Type: elemType,
+		}, nil
+	case *types.Struct:
+		if t.NumFields() == 0 {
+			return PredeclaredType("struct{}"), nil
+		}
+	}
+
+	// TODO: Struct, UnsafePointer
+	return nil, fmt.Errorf("can't yet turn %v (%T) into a model.Type", t.String(), t)
+}

--- a/mockgen/model/model_gotypes.go
+++ b/mockgen/model/model_gotypes.go
@@ -36,8 +36,7 @@ func funcArgsFromGoTypesType(t *types.Signature) (in []*Parameter, variadic *Par
 	}
 	var p *Parameter
 	for i := 0; i < nin; i++ {
-		p, err = parameterFromGoTypesType(t.Params().At(i), false)
-		if err != nil {
+		if p, err = parameterFromGoTypesType(t.Params().At(i), false); err != nil {
 			return
 		}
 		in = append(in, p)

--- a/mockgen/model/model_gotypes.go
+++ b/mockgen/model/model_gotypes.go
@@ -157,8 +157,8 @@ func typeFromGoTypesType(t types.Type) (Type, error) {
 		if t.NumFields() == 0 {
 			return PredeclaredType("struct{}"), nil
 		}
+		// TODO: UnsafePointer
 	}
 
-	// TODO: Struct, UnsafePointer
 	return nil, fmt.Errorf("can't yet turn %v (%T) into a model.Type", t.String(), t)
 }


### PR DESCRIPTION
This adds support for a 3rd option for creating mocks after reflect and source-mode: the archive mode. Archive mode lets you load archive files to create mocks. This can come in handy for writing Bazel rules that produce intermediary archive files and automatically codegen mocks in Bazel environments.

Rebased version of #125 