### PR TITLE
feat(bazel): support archive mode

### DIFF
--- a/bazel/go.mod
+++ b/bazel/go.mod
@@ -2,4 +2,4 @@ module go.uber.org/mock/bazel
 
 go 1.23.0
 
-require go.uber.org/mock v0.4.0
+require go.uber.org/mock v0.5.3-0.20250612195617-359202c7b2fe

--- a/bazel/go.sum
+++ b/bazel/go.sum
@@ -1,2 +1,2 @@
-go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
-go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
+go.uber.org/mock v0.5.3-0.20250612195617-359202c7b2fe h1:RZLb3fA2lGyj9wI0+49h3liYevFS0HC3gb1j/CocDOU=
+go.uber.org/mock v0.5.3-0.20250612195617-359202c7b2fe/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=


### PR DESCRIPTION
Removes the broken reflect mode in the bazel aspect, in favor of archive mode which was landed in #258 