### PR TITLE
Added WithStack method to Call struct

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -17,6 +17,7 @@ package gomock
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -297,6 +298,22 @@ func (c *Call) After(preReq *Call) *Call {
 	}
 
 	c.preReqs = append(c.preReqs, preReq)
+	return c
+}
+
+// WithStack add call stack to origin
+func (c *Call) WithStack(lvl int) *Call {
+	if lvl < 1 {
+		return c
+	}
+	strb := &strings.Builder{}
+	for i := lvl; i > 0; i-- {
+		if _, file, line, ok := runtime.Caller(i); ok {
+			strb.WriteString(fmt.Sprintf("\n%s:%d", file, line))
+		}
+	}
+	strb.WriteString("\n")
+	c.origin = strb.String()
 	return c
 }
 


### PR DESCRIPTION
This method allow to see not only file:line where the mock was called from, but also some file:line entries down the stack.

### Why do I need it?
#269

Some times i like to declare my mock calls not directly in the test, but in a helper function. And than i use this helper function to make my tests more readable. 
 When mock expectations fails error message point me to the helper function
file:line position, but i want also see where it was called in the test func

