### PR TITLE
Fix panic when trying to print a nil Stringer

### DIFF
--- a/gomock/string_test.go
+++ b/gomock/string_test.go
@@ -1,0 +1,47 @@
+package gomock
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetString(t *testing.T) {
+	now := time.Now()
+	var nilTime *time.Time
+
+	tests := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{
+			name:  "nil stringer should not panic",
+			input: nilTime,
+			want:  "<nil>",
+		},
+		{
+			name:  "non-nil stringer",
+			input: &now,
+			want:  now.String(),
+		},
+		{
+			name:  "non-stringer value",
+			input: 42,
+			want:  "42",
+		},
+		{
+			name:  "nil interface value",
+			input: nil,
+			want:  "<nil>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getString(tt.input)
+			if got != tt.want {
+				t.Errorf("getString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This fixes an issue where we're trying to print the value of a nil Stringer which causes a panic instead of failing the test, hurting the debuggability of the failure.

Fixes #283.