### PR TITLE
all: modernize code

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -129,7 +129,7 @@ func (c *Call) DoAndReturn(f any) *Call {
 			return nil
 		}
 		vArgs := make([]reflect.Value, len(args))
-		for i := 0; i < len(args); i++ {
+		for i := range args {
 			if args[i] != nil {
 				vArgs[i] = reflect.ValueOf(args[i])
 			} else {
@@ -170,7 +170,7 @@ func (c *Call) Do(f any) *Call {
 			return nil
 		}
 		vArgs := make([]reflect.Value, len(args))
-		for i := 0; i < len(args); i++ {
+		for i := range args {
 			if args[i] != nil {
 				vArgs[i] = reflect.ValueOf(args[i])
 			} else {
@@ -437,7 +437,7 @@ func (c *Call) call() []func([]any) []any {
 // mock with an embedded *Call.
 func InOrder(args ...any) {
 	calls := make([]*Call, 0, len(args))
-	for i := 0; i < len(args); i++ {
+	for i := range args {
 		if call := getCall(args[i]); call != nil {
 			calls = append(calls, call)
 			continue

--- a/gomock/callset_test.go
+++ b/gomock/callset_test.go
@@ -29,7 +29,7 @@ func TestCallSetAdd(t *testing.T) {
 	cs := newCallSet()
 
 	numCalls := 10
-	for i := 0; i < numCalls; i++ {
+	for range numCalls {
 		cs.Add(newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func)))
 	}
 
@@ -68,7 +68,7 @@ func TestCallSetRemove(t *testing.T) {
 	ourCalls := []*Call{}
 
 	numCalls := 10
-	for i := 0; i < numCalls; i++ {
+	for i := range numCalls {
 		// NOTE: abuse the `numCalls` value to convey initial ordering of mocked calls
 		generatedCall := &Call{receiver: receiver, method: method, numCalls: i}
 		cs.Add(generatedCall)

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -393,7 +393,7 @@ func TestAnyTimes(t *testing.T) {
 	subject := new(Subject)
 
 	ctrl.RecordCall(subject, "FooMethod", "argument").AnyTimes()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ctrl.Call(subject, "FooMethod", "argument")
 	}
 	reporter.assertPass("After 100 method calls.")
@@ -419,7 +419,7 @@ func TestMinTimes1(t *testing.T) {
 	_, ctrl = createFixtures(t)
 	subject = new(Subject)
 	ctrl.RecordCall(subject, "FooMethod", "argument").MinTimes(1)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ctrl.Call(subject, "FooMethod", "argument")
 	}
 	ctrl.Finish()
@@ -492,7 +492,7 @@ func TestMinMaxTimes(t *testing.T) {
 	_, ctrl = createFixtures(t)
 	subject = new(Subject)
 	ctrl.RecordCall(subject, "FooMethod", "argument").MaxTimes(1).MinTimes(2)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ctrl.Call(subject, "FooMethod", "argument")
 	}
 	ctrl.Finish()

--- a/mockgen/internal/tests/build_constraint/input.go
+++ b/mockgen/internal/tests/build_constraint/input.go
@@ -2,4 +2,4 @@ package empty_interface
 
 //go:generate mockgen -package empty_interface -destination mock.go -source input.go "-build_constraint=(linux && 386) || (darwin && !cgo) || usertag"
 
-type Empty interface{}
+type Empty any

--- a/mockgen/internal/tests/copyright_file/input.go
+++ b/mockgen/internal/tests/copyright_file/input.go
@@ -2,4 +2,4 @@ package empty_interface
 
 //go:generate mockgen -package empty_interface -destination mock.go -source input.go -copyright_file=mock_copyright_header
 
-type Empty interface{} // migrating interface{} -> any does not resolve to an interface type dropping test generation added in b391ab3
+type Empty any // migrating interface{} -> any does not resolve to an interface type dropping test generation added in b391ab3

--- a/mockgen/internal/tests/empty_interface/input.go
+++ b/mockgen/internal/tests/empty_interface/input.go
@@ -2,4 +2,4 @@ package empty_interface
 
 //go:generate mockgen -package empty_interface -destination mock.go -source input.go
 
-type Empty interface{} // migrating interface{} -> any does not resolve to an interface type.
+type Empty any // migrating interface{} -> any does not resolve to an interface type.

--- a/mockgen/internal/tests/package_comment/input.go
+++ b/mockgen/internal/tests/package_comment/input.go
@@ -2,4 +2,4 @@ package empty_interface
 
 //go:generate mockgen -package empty_interface -destination mock.go -source input.go -write_package_comment=false
 
-type Empty interface{}
+type Empty any

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -937,8 +937,8 @@ func parsePackageImport(srcDir string) (string, error) {
 	goPathList := strings.Split(goPaths, string(os.PathListSeparator))
 	for _, goPath := range goPathList {
 		sourceRoot := filepath.Join(goPath, "src") + string(os.PathSeparator)
-		if strings.HasPrefix(srcDir, sourceRoot) {
-			return filepath.ToSlash(strings.TrimPrefix(srcDir, sourceRoot)), nil
+		if after, ok := strings.CutPrefix(srcDir, sourceRoot); ok {
+			return filepath.ToSlash(after), nil
 		}
 	}
 	return "", errOutsideGoPath

--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -27,6 +27,7 @@ import (
 	"go/token"
 	"go/types"
 	"log"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -300,9 +301,7 @@ func (p *fileParser) parsePackage(path string) (*fileParser, error) {
 			newP.importedInterfaces.Set(path, ni.name.Name, ni)
 		}
 		imports, _ := importsOfFile(file)
-		for pkgName, pkgI := range imports {
-			newP.imports[pkgName] = pkgI
-		}
+		maps.Copy(newP.imports, imports)
 	}
 	return newP, nil
 }


### PR DESCRIPTION
Run modernize over the repository to update old Go idioms.
Changes include:

    for i := 0; i < N; i++            ->  for i := range N
    interface{}                       ->  any
    for k, v := range x { y[k] = v }  ->  maps.Copy(y, x)
    HasPrefix+TrimPrefix              ->  CutPrefix

Change generated by running:

```
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...
```
