### PR TITLE
mockgen: don't run `go list` in archive mode

### DIFF
--- a/mockgen/archive.go
+++ b/mockgen/archive.go
@@ -11,27 +11,39 @@ import (
 	"golang.org/x/tools/go/gcexportdata"
 )
 
-func parseExportFile(importPath string, symbols []string, archive string) (*model.Package, error) {
+// parseExportFile builds the package model from an archive's export data and
+// returns each import's package name, so callers need no `go list`.
+func parseExportFile(importPath string, symbols []string, archive string) (*model.Package, map[string]string, error) {
 	f, err := os.Open(archive)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer f.Close()
 	r, err := gcexportdata.NewReader(f)
 	if err != nil {
-		return nil, fmt.Errorf("read export data %q: %v", archive, err)
+		return nil, nil, fmt.Errorf("read export data %q: %v", archive, err)
 	}
 
 	fset := token.NewFileSet()
 	imports := make(map[string]*types.Package)
 	tp, err := gcexportdata.Read(r, fset, imports, importPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	interfaces, err := extractInterfacesFromPackageTypes(tp, symbols)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+
+	// Package names come from the export data; they can differ from the path
+	// basename (e.g. "gopkg.in/yaml.v3" is package "yaml").
+	importNames := make(map[string]string, len(imports)+1)
+	importNames[tp.Path()] = tp.Name()
+	for path, p := range imports {
+		if p != nil && p.Name() != "" {
+			importNames[path] = p.Name()
+		}
 	}
 
 	pkg := &model.Package{
@@ -39,5 +51,5 @@ func parseExportFile(importPath string, symbols []string, archive string) (*mode
 		PkgPath:    tp.Path(),
 		Interfaces: interfaces,
 	}
-	return pkg, nil
+	return pkg, importNames, nil
 }

--- a/mockgen/gob.go
+++ b/mockgen/gob.go
@@ -7,15 +7,19 @@ import (
 	"go.uber.org/mock/mockgen/model"
 )
 
-func gobMode(path string) (*model.Package, error) {
+func gobMode(path string) (*model.Package, map[string]string, error) {
 	in, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer in.Close()
 	var pkg model.Package
 	if err := gob.NewDecoder(in).Decode(&pkg); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &pkg, nil
+	importNames, err := resolveImportNames(&pkg)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &pkg, importNames, nil
 }

--- a/mockgen/gob_test.go
+++ b/mockgen/gob_test.go
@@ -14,7 +14,7 @@ func TestGobMode(t *testing.T) {
 
 	// Encode a package to a temporary gob.
 	parser := packageModeParser{}
-	want, err := parser.parsePackage(
+	want, _, err := parser.parsePackage(
 		"go.uber.org/mock/mockgen/internal/tests/package_mode", /* package name */
 		[]string{"Human", "Earth"},                             /* ifaces */
 	)
@@ -26,7 +26,7 @@ func TestGobMode(t *testing.T) {
 	outfile.Close()
 
 	// Ensure gobMode loads it correctly.
-	got, err := gobMode(path)
+	got, _, err := gobMode(path)
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
 }

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -27,11 +27,13 @@ import (
 	"go/token"
 	"io"
 	"log"
+	"maps"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -89,13 +91,14 @@ func main() {
 	var pkg *model.Package
 	var err error
 	var packageName string
+	var importNames map[string]string
 
 	// Switch between modes
 	switch {
 	case *modelGob != "": // gob mode
-		pkg, err = gobMode(*modelGob)
+		pkg, importNames, err = gobMode(*modelGob)
 	case *source != "": // source mode
-		pkg, err = sourceMode(*source)
+		pkg, importNames, err = sourceMode(*source)
 	case *archive != "": // archive mode
 		checkArgsArchive()
 		packageName = flag.Arg(0)
@@ -104,7 +107,7 @@ func main() {
 			interfaces = strings.Split(flag.Arg(1), ",")
 		}
 		// If no interfaces specified, parseExportFile will discover all interfaces
-		pkg, err = parseExportFile(packageName, interfaces, *archive)
+		pkg, importNames, err = parseExportFile(packageName, interfaces, *archive)
 
 	default: // package mode
 		checkArgsPackage()
@@ -123,7 +126,7 @@ func main() {
 
 		}
 		parser := packageModeParser{}
-		pkg, err = parser.parsePackage(packageName, interfaces)
+		pkg, importNames, err = parser.parsePackage(packageName, interfaces)
 	}
 
 	if err != nil {
@@ -165,6 +168,7 @@ func main() {
 
 	g := &generator{
 		buildConstraint: *buildConstraint,
+		importNames:     importNames,
 	}
 	if *source != "" {
 		g.filename = *source
@@ -300,7 +304,12 @@ type generator struct {
 	copyrightHeader           string
 	buildConstraint           string // may be empty
 
-	packageMap map[string]string // map from import path to package name
+	// packageMap maps import path to the unique local alias emitted in the
+	// generated code; it is derived from importNames.
+	packageMap map[string]string
+
+	// importNames maps import path to package name, as provided by the caller.
+	importNames map[string]string
 }
 
 func (g *generator) p(format string, args ...any) {
@@ -403,8 +412,6 @@ func (g *generator) Generate(pkg *model.Package, outputPkgName string, outputPac
 	}
 	sort.Strings(sortedPaths)
 
-	packagesName := createPackageMap(sortedPaths)
-
 	definedImports := make(map[string]string, len(im))
 	if *imports != "" {
 		for _, kv := range strings.Split(*imports, ",") {
@@ -418,7 +425,7 @@ func (g *generator) Generate(pkg *model.Package, outputPkgName string, outputPac
 	g.packageMap = make(map[string]string, len(im))
 	localNames := make(map[string]bool, len(im))
 	for _, pth := range sortedPaths {
-		base, ok := packagesName[pth]
+		base, ok := g.importNames[pth]
 		if !ok {
 			base = sanitize(path.Base(pth))
 		}
@@ -881,30 +888,47 @@ func (g *generator) Output() []byte {
 	return src
 }
 
-// createPackageMap returns a map of import path to package name
-// for specified importPaths.
-func createPackageMap(importPaths []string) map[string]string {
-	var pkg struct {
-		Name       string
-		ImportPath string
+// resolveImportNames resolves pkg's imports to package names via `go list`
+// (source and gob modes). Returns nil for no imports, so `go list` isn't run empty.
+func resolveImportNames(pkg *model.Package) (map[string]string, error) {
+	importSet := pkg.Imports()
+	if len(importSet) == 0 {
+		return nil, nil
 	}
-	pkgMap := make(map[string]string)
-	b := bytes.NewBuffer(nil)
-	args := []string{"list", "-json=ImportPath,Name"}
-	args = append(args, importPaths...)
+	return goListImportNames(slices.Collect(maps.Keys(importSet)))
+}
+
+// goListImportNames resolves import paths to package names via `go list -e`.
+// Unresolvable imports are dropped (callers fall back to the basename); only a
+// `go list` invocation failure returns an error.
+func goListImportNames(importPaths []string) (map[string]string, error) {
+	var stdout, stderr bytes.Buffer
+	args := append([]string{"list", "-e", "-json=ImportPath,Name"}, importPaths...)
 	cmd := exec.Command("go", args...)
-	cmd.Stdout = b
-	cmd.Run()
-	dec := json.NewDecoder(b)
-	for dec.More() {
-		err := dec.Decode(&pkg)
-		if err != nil {
-			log.Printf("failed to decode 'go list' output: %v", err)
-			continue
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return nil, fmt.Errorf("go list: %w: %s", err, msg)
 		}
-		pkgMap[pkg.ImportPath] = pkg.Name
+		return nil, fmt.Errorf("go list: %w", err)
 	}
-	return pkgMap
+	names := make(map[string]string)
+	dec := json.NewDecoder(&stdout)
+	for dec.More() {
+		// Fresh per iteration: json.Decode won't clear a Name absent under -e.
+		var pkg struct {
+			Name       string
+			ImportPath string
+		}
+		if err := dec.Decode(&pkg); err != nil {
+			return nil, fmt.Errorf("decoding 'go list' output: %w", err)
+		}
+		if pkg.Name != "" {
+			names[pkg.ImportPath] = pkg.Name
+		}
+	}
+	return names, nil
 }
 
 func printVersion() {

--- a/mockgen/mockgen_test.go
+++ b/mockgen/mockgen_test.go
@@ -340,7 +340,7 @@ func TestGetArgNames(t *testing.T) {
 	}
 }
 
-func Test_createPackageMap(t *testing.T) {
+func Test_goListImportNames(t *testing.T) {
 	tests := []struct {
 		name            string
 		importPath      string
@@ -349,22 +349,93 @@ func Test_createPackageMap(t *testing.T) {
 	}{
 		{"golang package", "context", "context", true},
 		{"third party", "golang.org/x/tools/present", "present", true},
+		// Unresolvable: must be dropped, not inherit the previous entry's name.
+		{"unresolvable omitted", "go.uber.org/mock/mockgen/internal/does_not_exist_xyz", "", false},
 	}
 	var importPaths []string
 	for _, t := range tests {
 		importPaths = append(importPaths, t.importPath)
 	}
-	packages := createPackageMap(importPaths)
+	packages, err := goListImportNames(importPaths)
+	if err != nil {
+		t.Fatalf("goListImportNames() error = %v", err)
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotPackageName, gotOk := packages[tt.importPath]
 			if gotPackageName != tt.wantPackageName {
-				t.Errorf("createPackageMap() gotPackageName = %v, wantPackageName = %v", gotPackageName, tt.wantPackageName)
+				t.Errorf("goListImportNames() gotPackageName = %v, wantPackageName = %v", gotPackageName, tt.wantPackageName)
 			}
 			if gotOk != tt.wantOK {
-				t.Errorf("createPackageMap() gotOk = %v, wantOK = %v", gotOk, tt.wantOK)
+				t.Errorf("goListImportNames() gotOk = %v, wantOK = %v", gotOk, tt.wantOK)
 			}
 		})
+	}
+}
+
+func Test_resolveImportNames(t *testing.T) {
+	// No imports must not run `go list` (with no args it lists the cwd package).
+	empty := &model.Package{Interfaces: []*model.Interface{{Name: "Empty"}}}
+	names, err := resolveImportNames(empty)
+	if err != nil {
+		t.Fatalf("resolveImportNames(no imports) error = %v", err)
+	}
+	if names != nil {
+		t.Errorf("resolveImportNames(no imports) = %v, want nil", names)
+	}
+
+	withImport := &model.Package{Interfaces: []*model.Interface{{
+		Name: "I",
+		Methods: []*model.Method{{
+			Name: "M",
+			In:   []*model.Parameter{{Type: &model.NamedType{Package: "time", Type: "Duration"}}},
+		}},
+	}}}
+	names, err = resolveImportNames(withImport)
+	if err != nil {
+		t.Fatalf("resolveImportNames() error = %v", err)
+	}
+	if names["time"] != "time" {
+		t.Errorf(`resolveImportNames()["time"] = %q, want "time"`, names["time"])
+	}
+}
+
+// Test_Generate_usesPreResolvedPackageNames: Generate aliases imports from
+// g.importNames — path basename "v2" but alias "bar" proves the map is used.
+func Test_Generate_usesPreResolvedPackageNames(t *testing.T) {
+	pkg := &model.Package{
+		Name:    "greeter",
+		PkgPath: "example.com/greeter",
+		Interfaces: []*model.Interface{
+			{
+				Name: "Greeter",
+				Methods: []*model.Method{
+					{
+						Name: "Greet",
+						Out: []*model.Parameter{
+							{Type: &model.NamedType{Package: "example.com/foo/v2", Type: "Message"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	g := &generator{
+		importNames: map[string]string{
+			"example.com/foo/v2": "bar",
+		},
+	}
+	if err := g.Generate(pkg, "mock_greeter", ""); err != nil {
+		t.Fatalf("Generate() error = %v", err)
+	}
+
+	out := g.buf.String()
+	if !strings.Contains(out, `bar "example.com/foo/v2"`) {
+		t.Errorf("expected import aliased to pre-resolved name %q, got:\n%s", "bar", out)
+	}
+	if strings.Contains(out, `v2 "example.com/foo/v2"`) {
+		t.Errorf("import fell back to path basename instead of pre-resolved name:\n%s", out)
 	}
 }
 

--- a/mockgen/package_mode.go
+++ b/mockgen/package_mode.go
@@ -17,18 +17,20 @@ var (
 
 type packageModeParser struct{}
 
-func (p *packageModeParser) parsePackage(packageName string, ifaces []string) (*model.Package, error) {
+// parsePackage returns the package model and a map of import path to package
+// name from the loaded export data.
+func (p *packageModeParser) parsePackage(packageName string, ifaces []string) (*model.Package, map[string]string, error) {
 	pkg, err := p.loadPackage(packageName)
 	if err != nil {
-		return nil, fmt.Errorf("load package: %w", err)
+		return nil, nil, fmt.Errorf("load package: %w", err)
 	}
 
-	modelPackage, err := parseExportFile(packageName, ifaces, pkg.ExportFile)
+	modelPackage, importNames, err := parseExportFile(packageName, ifaces, pkg.ExportFile)
 	if err != nil {
-		return nil, fmt.Errorf("extract interfaces from package: %w", err)
+		return nil, nil, fmt.Errorf("extract interfaces from package: %w", err)
 	}
 
-	return modelPackage, nil
+	return modelPackage, importNames, nil
 }
 
 func (p *packageModeParser) loadPackage(packageName string) (*packages.Package, error) {
@@ -64,7 +66,7 @@ func (p *packageModeParser) loadPackage(packageName string) (*packages.Package, 
 
 func extractInterfacesFromPackageTypes(pkgTypes *types.Package, ifaces []string) ([]*model.Interface, error) {
 	// If no interfaces specified, discover all interfaces in the package
-	if len(ifaces) == 0  {
+	if len(ifaces) == 0 {
 		return getAllInterfacesFromPackageTypes(pkgTypes)
 	}
 	scope := pkgTypes.Scope()

--- a/mockgen/package_mode_test.go
+++ b/mockgen/package_mode_test.go
@@ -8,6 +8,39 @@ import (
 	"go.uber.org/mock/mockgen/model"
 )
 
+// Test_packageModeParser_parsePackage_resolvesPackageNames: parsePackage returns
+// real export-data names for the name≠basename case (client/v1 is package "client").
+func Test_packageModeParser_parsePackage_resolvesPackageNames(t *testing.T) {
+	parser := packageModeParser{}
+	_, importNames, err := parser.parsePackage(
+		"go.uber.org/mock/mockgen/internal/tests/custom_package_name/greeter",
+		[]string{"InputMaker"},
+	)
+	require.NoError(t, err)
+
+	const clientV1 = "go.uber.org/mock/mockgen/internal/tests/custom_package_name/client/v1"
+	assert.Equal(t, "client", importNames[clientV1],
+		"parseExportFile must resolve the real package name from export data, not the path basename")
+}
+
+// Test_packageMode_endToEnd_importAliasing feeds the real parsePackage name map
+// into Generate and checks the emitted alias is "client", not basename "v1".
+func Test_packageMode_endToEnd_importAliasing(t *testing.T) {
+	parser := packageModeParser{}
+	pkg, importNames, err := parser.parsePackage(
+		"go.uber.org/mock/mockgen/internal/tests/custom_package_name/greeter",
+		[]string{"InputMaker"},
+	)
+	require.NoError(t, err)
+
+	g := &generator{importNames: importNames}
+	require.NoError(t, g.Generate(pkg, "mock_greeter", ""))
+
+	assert.Contains(t, g.buf.String(),
+		`client "go.uber.org/mock/mockgen/internal/tests/custom_package_name/client/v1"`,
+		"real export-data name map must flow into Generate and alias .../client/v1 as package \"client\"")
+}
+
 func Test_packageModeParser_parsePackage(t *testing.T) {
 	type args struct {
 		packageName string
@@ -360,7 +393,7 @@ func Test_packageModeParser_parsePackage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := packageModeParser{}
-			actual, err := parser.parsePackage(tt.args.packageName, tt.args.ifaces)
+			actual, _, err := parser.parsePackage(tt.args.packageName, tt.args.ifaces)
 
 			if tt.expectedErr != "" {
 				assert.ErrorContains(t, err, tt.expectedErr)
@@ -389,7 +422,7 @@ func Test_packageModeParser_parsePackage(t *testing.T) {
 		}
 
 		parser := packageModeParser{}
-		actual, err := parser.parsePackage(expected.PkgPath, []string{})
+		actual, _, err := parser.parsePackage(expected.PkgPath, []string{})
 		require.NoError(t, err)
 		require.NotNil(t, actual)
 		assert.Equal(t, expected.Name, actual.Name)
@@ -544,7 +577,7 @@ func TestAliases(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			var parser packageModeParser
-			actual, err := parser.parsePackage(packageName, []string{tt.iface})
+			actual, _, err := parser.parsePackage(packageName, []string{tt.iface})
 			require.NoError(t, err)
 			require.NotNil(t, actual)
 			require.Len(t, actual.Interfaces, 1)

--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -37,21 +37,21 @@ import (
 )
 
 // sourceMode generates mocks via source file.
-func sourceMode(source string) (*model.Package, error) {
+func sourceMode(source string) (*model.Package, map[string]string, error) {
 	srcDir, err := filepath.Abs(filepath.Dir(source))
 	if err != nil {
-		return nil, fmt.Errorf("failed getting source directory: %v", err)
+		return nil, nil, fmt.Errorf("failed getting source directory: %v", err)
 	}
 
 	packageImport, err := parsePackageImport(srcDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	fs := token.NewFileSet()
 	file, err := parser.ParseFile(fs, source, nil, 0)
 	if err != nil {
-		return nil, fmt.Errorf("failed parsing source file %v: %v", source, err)
+		return nil, nil, fmt.Errorf("failed parsing source file %v: %v", source, err)
 	}
 
 	p := &fileParser{
@@ -64,7 +64,7 @@ func sourceMode(source string) (*model.Package, error) {
 
 	// positional interface names -> include set
 	if flag.NArg() > 1 {
-		return nil, errors.New("-source mode accepts at most one argument")
+		return nil, nil, errors.New("-source mode accepts at most one argument")
 	}
 	if flag.NArg() == 1 {
 		ifaces := strings.Split(flag.Arg(0), ",")
@@ -94,19 +94,23 @@ func sourceMode(source string) (*model.Package, error) {
 
 	// Handle -aux_files.
 	if err := p.parseAuxFiles(*auxFiles); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	p.addAuxInterfacesFromFile(packageImport, file) // this file
 
 	pkg, err := p.parseFile(packageImport, file)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for pkgPath := range dotImports {
 		pkg.DotImports = append(pkg.DotImports, pkgPath)
 	}
 
-	return pkg, nil
+	importNames, err := resolveImportNames(pkg)
+	if err != nil {
+		return nil, nil, err
+	}
+	return pkg, importNames, nil
 }
 
 type importedPackage interface {
@@ -710,7 +714,11 @@ func importsOfFile(file *ast.File) (normalImports map[string]importedPackage, do
 		importPath := is.Path.Value[1 : len(is.Path.Value)-1] // remove quotes
 		importPaths = append(importPaths, importPath)
 	}
-	packagesName := createPackageMap(importPaths)
+	importNames, err := goListImportNames(importPaths)
+	if err != nil {
+		// Best-effort here: names fall back to import-path suffixes below.
+		log.Printf("failed to resolve import names via 'go list': %v", err)
+	}
 	normalImports = make(map[string]importedPackage)
 	dotImports = make([]string, 0)
 	for _, is := range file.Imports {
@@ -724,7 +732,7 @@ func importsOfFile(file *ast.File) (normalImports map[string]importedPackage, do
 			}
 			pkgName = is.Name.Name
 		} else {
-			pkg, ok := packagesName[importPath]
+			pkg, ok := importNames[importPath]
 			if !ok {
 				// Fallback to import path suffix. Note that this is uncertain.
 				_, last := path.Split(importPath)


### PR DESCRIPTION
Generate always shelled out to `go list` to resolve import package names, even in archive mode — so mockgen needed the `go` toolchain even when handed a prebuilt export archive, breaking hermetic builds (Buck, Bazel).

Archive and package modes now take those names straight from the export data they already load; only source and reflect/gob modes still use `go list`. Generate just consumes the resolved names, falling back to the path basename for the rest.

`go list` failures are also surfaced now instead of swallowed (with `-e` so unresolvable imports fall back rather than abort). Adds tests for name resolution and the `go list` helper.

Note: source and reflect/gob modes now fail loudly on a genuine `go list` invocation error (missing toolchain / broken module) where they previously degraded silently — `-e` keeps ordinary unresolvable-package errors non-fatal.