### PR TITLE
mockgen: format generated code without invoking `go`

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -874,7 +874,15 @@ func (o identifierAllocator) allocateIdentifier(want string) string {
 
 // Output returns the generator's output, formatted in the standard Go style.
 func (g *generator) Output() []byte {
-	src, err := toolsimports.Process(g.destination, g.buf.Bytes(), nil)
+	// FormatOnly keeps formatting hermetic: mockgen already emits a complete,
+	// self-consistent import set, so goimports' add/remove pass (which shells
+	// out to `go` and breaks in Buck/Bazel) is unnecessary.
+	src, err := toolsimports.Process(g.destination, g.buf.Bytes(), &toolsimports.Options{
+		Comments:   true,
+		TabIndent:  true,
+		TabWidth:   8,
+		FormatOnly: true,
+	})
 	if err != nil {
 		log.Fatalf("Failed to format generated source code: %s\n%s", err, g.buf.String())
 	}


### PR DESCRIPTION
mockgen formats its output with goimports (`x/tools`, `imports.Process`). With the default options that pass also inserts and deletes imports, and **since x/tools v0.27.0 it shells out to `go` unconditionally** — even when there is nothing to fix. So mockgen needs the `go` toolchain in `$PATH` purely to format its output, which breaks hermetic builds (Buck, Bazel):

```
Failed to format generated source code: exec: "go": executable file not found in $PATH
```

mockgen already computes a complete, self-consistent import set (it even excludes the self/output package), so goimports has nothing to add or remove. Passing `FormatOnly: true` keeps the gofmt formatting and stdlib/third-party import grouping while skipping the `go` invocation.

### Verification
- `go generate ./...` produces **byte-for-byte identical** output across the whole mock corpus (the insert/delete pass was a no-op).
- `go build ./...` and `go test ./...` pass.
- Running archive mode with `go` removed from `$PATH` now generates and formats a mock successfully (previously failed with the error above).

Bisected the regression to x/tools v0.27.0 (v0.26.0 formats hermetically; v0.27.0+ requires `go`).